### PR TITLE
Add __eq__ to Node

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,8 @@ Changelog
 Next
 ----
 
+- Compare ``Node`` objects based on the ``public_ip_address`` and ``private_ip_address``.
+
 2018.06.27.0
 ------------
 

--- a/spelling_private_dict.txt
+++ b/spelling_private_dict.txt
@@ -40,6 +40,7 @@ genconf
 homebrew
 hwclock
 idna
+iff
 init
 invalidversion
 ip

--- a/src/dcos_e2e/node.py
+++ b/src/dcos_e2e/node.py
@@ -73,6 +73,17 @@ class Node:
         self._ssh_key_path = ssh_key_path
         self.default_transport = default_transport
 
+    def __eq__(self, other: Any) -> bool:
+        """
+        Compare a ``Node`` object against another one based on its attributes,
+        namely the ``public_ip_address`` and ``private_ip_address``.
+        """
+
+        return bool(
+            self.public_ip_address == other.public_ip_address
+            and self.private_ip_address == other.private_ip_address,
+        )
+
     def __str__(self) -> str:
         """
         Convert a `Node` object to string listing only its IP addresses.


### PR DESCRIPTION
This PR adds a `__eq__` function to a `Node` so that `Node`s with the same `public_ip_address` and `private_ip_address` are considered equal when they are compare by `==`.