### PR TITLE
Execute node-poststart for DC/OS 1.10, 1.11 and master

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Changelog
 Next
 ----
 
+- Execute ``node-poststart`` checks in ``Cluster.wait_for_dcos`` and ``Cluster.wait_for_dcos_ee``.
 - Add ``dcos-vagrant doctor`` checks.
 
 2018.07.03.5

--- a/spelling_private_dict.txt
+++ b/spelling_private_dict.txt
@@ -74,6 +74,7 @@ plugin
 plugins
 popen
 postflight
+poststart
 powershell
 pragma
 preflight


### PR DESCRIPTION
This PR adds execution of `node-poststart` to all recent DC/OS versions when calling `Cluster.wait_for_dcos` and `Cluster.wait_for_dcos_ee`.