### PR TITLE
Add master host port map for Docker

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,11 @@ Next
 - Add ``virtualbox_description`` parameter to the ``Vagrant`` backend.
 - Change the default transport for the Docker backend to ``DOCKER_EXEC``.
 
+2018.07.15.0
+------------
+
+- Add a ``--one-master-host-port-map`` option to ``dcos-docker create``.
+
 2018.07.10.0
 ------------
 

--- a/src/cli/dcos_docker/commands/create.py
+++ b/src/cli/dcos_docker/commands/create.py
@@ -78,6 +78,61 @@ def _validate_docker_network(
         raise click.BadParameter(message=message)
 
 
+def _validate_port_map(
+    ctx: click.core.Context,
+    param: Union[click.core.Option, click.core.Parameter],
+    value: Any,
+) -> Dict[str, int]:
+    """
+    Turn port map strings into a Dict that ``docker-py`` can use.
+    """
+    # We "use" variables to satisfy linting tools.
+    for _ in (ctx, param):
+        pass
+
+    ports = {}  # type: Dict[str, int]
+    for ports_definition in value:
+        parts = ports_definition.split(':')
+
+        # Consider support the full docker syntax.
+        # https://docs.docker.com/engine/reference/run/#expose-incoming-ports
+        if len(parts) != 2:
+            message = (
+                '"{ports_definition}" is not a valid port map. '
+                'Please follow this syntax: <HOST_PORT>:<CONTAINER_PORT>'
+            ).format(ports_definition=ports_definition)
+            raise click.BadParameter(message=message)
+
+        host_port, container_port = parts
+        if not host_port.isdigit():
+            message = ('Host port "{host_port}" is not an integer.'
+                       ).format(host_port=host_port)
+            raise click.BadParameter(message=message)
+        if not container_port.isdigit():
+            message = ('Container port "{container_port}" is an integer.'
+                       ).format(container_port=container_port)
+            raise click.BadParameter(message=message)
+        if int(host_port) < 0 or int(host_port) > 65535:
+            message = ('Host port "{host_port}" is not a valid port number.'
+                       ).format(host_port=host_port)
+            raise click.BadParameter(message=message)
+        if int(container_port) < 0 or int(container_port) > 65535:
+            message = (
+                'Container port "{container_port}" is not a valid port number.'
+            ).format(container_port=container_port)
+            raise click.BadParameter(message=message)
+
+        key = container_port + '/tcp'
+        if key in ports:
+            message = (
+                'Container port "{container_port}" specified multiple times.'
+            ).format(container_port=container_port)
+            raise click.BadParameter(message=message)
+
+        ports[key] = int(host_port)
+    return ports
+
+
 def _validate_volumes(
     ctx: click.core.Context,
     param: Union[click.core.Option, click.core.Parameter],
@@ -280,6 +335,17 @@ def _write_key_pair(public_key_path: Path, private_key_path: Path) -> None:
     ),
 )
 @node_transport_option
+@click.option(
+    '--one-master-host-port-map',
+    type=str,
+    callback=_validate_port_map,
+    help=(
+        'Publish a container port of one master node to the host. '
+        'Only Transmission Control Protocol is supported currently. '
+        'The syntax is <HOST_PORT>:<CONTAINER_PORT>'
+    ),
+    multiple=True,
+)
 @click.pass_context
 def create(
     ctx: click.core.Context,
@@ -305,6 +371,7 @@ def create(
     transport: Transport,
     wait_for_dcos: bool,
     network: Network,
+    one_master_host_port_map: Dict[str, int],
 ) -> None:
     """
     Create a DC/OS cluster.
@@ -405,6 +472,7 @@ def create(
         workspace_dir=workspace_dir,
         transport=transport,
         network=network,
+        one_master_host_port_map=one_master_host_port_map,
     )
 
     try:

--- a/src/dcos_e2e/backends/_docker/_containers.py
+++ b/src/dcos_e2e/backends/_docker/_containers.py
@@ -6,7 +6,7 @@ import configparser
 import io
 import shlex
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 import docker
 
@@ -86,6 +86,7 @@ def start_dcos_container(
     docker_storage_driver: DockerStorageDriver,
     docker_version: DockerVersion,
     network: Optional[docker.models.networks.Network] = None,
+    ports: Optional[Dict[str, Any]] = None,
 ) -> None:
     """
     Start a master, agent or public agent container.
@@ -111,6 +112,7 @@ def start_dcos_container(
             node.
         network: The network to connect the container to other than the default
         ``docker0`` bridge network.
+        ports: The ports to expose on the host.
     """
     hostname = container_base_name + str(container_number)
     environment = {'container': hostname}
@@ -129,6 +131,7 @@ def start_dcos_container(
         labels=labels,
         stop_signal='SIGRTMIN+3',
         command=['/sbin/init'],
+        ports=ports or {},
     )
     if network:
         network.connect(container)

--- a/tests/test_cli/test_dcos_docker/test_cli.py
+++ b/tests/test_cli/test_dcos_docker/test_cli.py
@@ -229,6 +229,11 @@ class TestCreate:
                                               available. This can be provided by setting the
                                               `DCOS_DOCKER_TRANSPORT` environment variable.
                                               [default: docker-exec]
+              --one-master-host-port-map TEXT
+                                              Publish a container port of one master node to
+                                              the host. Only Transmission Control Protocol
+                                              is supported currently. The syntax is
+                                              <HOST_PORT>:<CONTAINER_PORT>
               --help                          Show this message and exit.
             """,# noqa: E501,E261
         )


### PR DESCRIPTION
Add an option to expose host ports for one of the master node. This is
useful on OSX on which the container IP is not directly accessible from
the host. By exposing the host ports, the user can reach the services on
the master node using the mapped host ports. The host port map will be
applied to one master only if there are multiple master nodes.

I tested on my mac locally:
```
$ dcos-docker create --transport docker-exec --public-agents 0 --agents 1 --one-master-host-port-map 80:80 ./dcos_generate_config.ee.sh
default
Cluster "default" has started. Run "dcos-docker wait --cluster-id default" to wait for DC/OS to become ready.
```