### PR TITLE
Update Mesos agent cgroup root

### DIFF
--- a/src/dcos_e2e/backends/_docker/_containers.py
+++ b/src/dcos_e2e/backends/_docker/_containers.py
@@ -139,6 +139,13 @@ def start_dcos_container(
         '/var/lib/dcos/mesos-slave-common'
     )
 
+    setup_mesos_cgroup_root = (
+        'MESOS_CGROUPS_ROOT=`grep memory /proc/1/cgroup | cut -d: -f3`/mesos; '
+        'MESOS_CGROUPS_ROOT=${MESOS_CGROUPS_ROOT:1}; '
+        'echo "MESOS_CGROUPS_ROOT=$MESOS_CGROUPS_ROOT" >> '
+        '/var/lib/dcos/mesos-slave-common'
+    )
+
     docker_service_name = 'docker.service'
     docker_service_text = _docker_service_file(
         storage_driver=docker_storage_driver,
@@ -163,6 +170,7 @@ def start_dcos_container(
         ['systemctl', 'enable', docker_service_name],
         ['systemctl', 'start', docker_service_name],
         ['/bin/bash', '-c', disable_systemd_support_cmd],
+        ['/bin/bash', '-c', setup_mesos_cgroup_root],
         ['mkdir', '--parents', '/root/.ssh'],
         '/bin/bash -c "{cmd}"'.format(cmd=' '.join(echo_key)),
         ['rm', '-f', '/run/nologin', '||', 'true'],


### PR DESCRIPTION
Instruct the Mesos agent in the DC/OS Docker container to use a cgroup
root that is under the cgroup used for the DC/OS Docker container.
Otherwise, if one runs multiple DC/OS agent nodes on a single machine,
they might see cgroups from each other, causing issues during recovery
because Mesos agent will kill tasks under unknown cgroups.

Fixes #1124