### PR TITLE
Install envsubst on base distributions

### DIFF
--- a/src/dcos_e2e/backends/_docker/resources/dockerfiles/base/centos-7/Dockerfile
+++ b/src/dcos_e2e/backends/_docker/resources/dockerfiles/base/centos-7/Dockerfile
@@ -6,6 +6,7 @@ RUN yum install -y \
 		btrfs-progs \
 		ca-certificates \
 		curl \
+		gettext \
 		git \
 		iproute \
 		ipset \
@@ -22,7 +23,7 @@ RUN yum install -y \
 		tree \
 		unzip \
 		which \
-                xfsprogs \
+		xfsprogs \
 		xz \
 && ( \
 cd /lib/systemd/system/sysinit.target.wants/; \

--- a/src/dcos_e2e/backends/_docker/resources/dockerfiles/base/ubuntu-xenial/Dockerfile
+++ b/src/dcos_e2e/backends/_docker/resources/dockerfiles/base/ubuntu-xenial/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update \
 		debianutils \
 		dbus \
 		gawk \
+		gettext \
 		git \
 		iproute \
 		ipset \
@@ -26,7 +27,7 @@ RUN apt-get update \
 		tar \
 		tree \
 		unzip \
-                xfsprogs \
+		xfsprogs \
 		xz-utils \
 	&& rm -rf /var/lib/apt/lists/* \
 && ( \


### PR DESCRIPTION
This is a dependency of the script that runs kubernetes on dcos.

CoreOS already have envsubst.