### PR TITLE
Add sanity check that we can connect to Docker when required

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,11 @@ Changelog
 Next
 ----
 
+2018.08.22.0
+------------
+
+- Improve diagnostics when creating a Docker-backed cluster with no running Docker daemon.
+
 2018.08.13.0
 ------------
 

--- a/src/cli/dcos_docker/commands/create.py
+++ b/src/cli/dcos_docker/commands/create.py
@@ -52,6 +52,7 @@ from ._common import (
     NODE_TYPE_PUBLIC_AGENT_LABEL_VALUE,
     VARIANT_LABEL_KEY,
     WORKSPACE_DIR_LABEL_KEY,
+    docker_client,
     existing_cluster_ids,
 )
 from ._options import node_transport_option
@@ -69,7 +70,7 @@ def _validate_docker_network(
     # We "use" variables to satisfy linting tools.
     for _ in (ctx, param):
         pass
-    client = docker.from_env(version='auto')
+    client = docker_client()
     try:
         return client.networks.get(network_id=value)
     except docker.errors.NotFound:


### PR DESCRIPTION
This patch provides an improved error message in case users forget to start the Docker daemon before running `dcos-docker` commands (I personally usually do not start Docker unless I need it).

Please see the commit message for more details.