### PR TITLE
Add a timeout and a custom DCOSTimeoutError to wait_for_dcos_oss/ee

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,8 @@ Changelog
 Next
 ----
 
+- Previously ``_wait_for_node_poststart`` and therefore ``wait_for_dcos_oss`` and ``wait_for_dcos_ee`` had a fixed number of retries on querying DC/OS ``node-poststart``. The fixed retry has been removed in favor of a ``timeout_seconds`` parameter for the ladder two functions.
+
 2018.09.06.0
 ------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ Changelog
 Next
 ----
 
-- Previously ``_wait_for_node_poststart`` and therefore ``wait_for_dcos_oss`` and ``wait_for_dcos_ee`` had a fixed number of retries on querying DC/OS ``node-poststart``. The fixed retry has been removed in favor of a ``timeout_seconds`` parameter for the ladder two functions.
+- ``wait_for_dcos_oss`` and ``wait_for_dcos_ee`` now raise a custom ``DCOSTimeoutError`` if DC/OS has not started within one hour.
 
 2018.09.06.0
 ------------

--- a/docs/source/exceptions.rst
+++ b/docs/source/exceptions.rst
@@ -1,6 +1,6 @@
 Exceptions
 ==========
 
-The following custom exceptions are defined dcos-e2e.
+The following custom exceptions are defined in dcos-e2e.
 
 .. autoclass:: dcos_e2e.exceptions.DCOSTimeoutError

--- a/docs/source/exceptions.rst
+++ b/docs/source/exceptions.rst
@@ -1,0 +1,6 @@
+Exceptions
+==========
+
+The following custom exceptions are defined dcos-e2e.
+
+.. autoclass:: dcos_e2e.exceptions.DCOSTimeoutError

--- a/docs/source/library.rst
+++ b/docs/source/library.rst
@@ -15,5 +15,6 @@ It includes a library which is focused on helping you to write tests which requi
    node
    enterprise
    distributions
+   exceptions
    docker-versions
    docker-storage-driver

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,4 +25,5 @@ retrying==1.3.3
 # https://github.com/tdsmith/homebrew-pypi-poet/blob/master/poet/poet.py
 # does not pin setuptools.
 setuptools>=40.4.2
+timeout-decorator==0.4.0
 urllib3==1.23

--- a/spelling_private_dict.txt
+++ b/spelling_private_dict.txt
@@ -1,4 +1,5 @@
 AbstractLauncher
+RetryError
 adam
 admin
 api

--- a/src/dcos_e2e/cluster.py
+++ b/src/dcos_e2e/cluster.py
@@ -269,7 +269,7 @@ class Cluster(ContextDecorator):
             # DC/OS Test Utils raises its own timeout, a
             # ``retrying.RetryError``.
             #
-            # At the time of writing it is not customisable when this is hit.
+            # At the time of writing it is not customizable when this is hit.
             # We want to only time out when ``timeout`` seconds have passed,
             # even if this is after DC/OS Test Utils' own timeout.
             # Therefore we ignore the DC/OS Test Utils ``RetryError`` and try
@@ -405,7 +405,7 @@ class Cluster(ContextDecorator):
             # DC/OS Test Utils raises its own timeout, a
             # ``retrying.RetryError``.
             #
-            # At the time of writing it is not customisable when this is hit.
+            # At the time of writing it is not customizable when this is hit.
             # We want to only time out when ``timeout`` seconds have passed,
             # even if this is after DC/OS Test Utils' own timeout.
             # Therefore we ignore the DC/OS Test Utils ``RetryError`` and try

--- a/src/dcos_e2e/cluster.py
+++ b/src/dcos_e2e/cluster.py
@@ -175,8 +175,7 @@ class Cluster(ContextDecorator):
             dcos_e2e.exceptions.DCOSTimeoutError: Raised if cluster components
                 did not become ready within the timeout boundary.
         """
-
-        if timeout_seconds < 1:
+        if timeout_seconds is not None and timeout_seconds < 1:
             message = '``timeout_seconds`` must be ``None`` or >= 1.'
             raise ValueError(message)
 
@@ -281,9 +280,9 @@ class Cluster(ContextDecorator):
             # long enough to hit that error.
             while True:
                 try:
-                    api_session.wait_for_dcos()
+                    api_session.wait_for_dcos()  # type: ignore
                 except retrying.RetryError:  # pragma: no cover
-                     pass
+                    pass
 
             # Only the first user can log in with SSO, before granting others
             # access.
@@ -327,8 +326,7 @@ class Cluster(ContextDecorator):
             dcos_e2e.exceptions.DCOSTimeoutError: Raised if cluster components
                 did not become ready within the timeout boundary.
         """
-
-        if timeout_seconds < 1:
+        if timeout_seconds is not None and timeout_seconds < 1:
             message = '``timeout_seconds`` must be ``None`` or >= 1.'
             raise ValueError(message)
 
@@ -420,7 +418,7 @@ class Cluster(ContextDecorator):
                 try:
                     enterprise_session.wait_for_dcos()
                 except retrying.RetryError:  # pragma: no cover
-                     pass
+                    pass
 
         wait_for_dcos_ee_until_timeout()
 

--- a/src/dcos_e2e/cluster.py
+++ b/src/dcos_e2e/cluster.py
@@ -156,7 +156,6 @@ class Cluster(ContextDecorator):
     def wait_for_dcos_oss(
         self,
         http_checks: bool = True,
-        timeout_seconds: Optional[int] = None,
     ) -> None:
         """
         Wait until the DC/OS OSS boot process has completed.
@@ -167,20 +166,19 @@ class Cluster(ContextDecorator):
                 fully ready. This is useful in cases where an HTTP connection
                 cannot be made to the cluster. For example, this is useful on
                 macOS without a VPN set up.
-            timeout_seconds: Optional timeout in seconds after which a DC/OS
-                start up is considered a failure.
 
         Raises:
-            ValueError: In case ``timeout_seconds`` is < 1.
             dcos_e2e.exceptions.DCOSTimeoutError: Raised if cluster components
-                did not become ready within the timeout boundary.
+                did not become ready within one hour.
         """
-        if timeout_seconds is not None and timeout_seconds < 1:
-            message = '``timeout_seconds`` must be ``None`` or >= 1.'
-            raise ValueError(message)
 
         @timeout_decorator.timeout(
-            timeout_seconds,
+            # We choose a one hour timeout based on experience that the cluster
+            # will almost certainly not start up after this time.
+            #
+            # In the future we may want to increase this or make it
+            # customizable.
+            60 * 60,
             timeout_exception=DCOSTimeoutError,
         )
         def wait_for_dcos_oss_until_timeout() -> None:
@@ -305,7 +303,6 @@ class Cluster(ContextDecorator):
         superuser_username: str,
         superuser_password: str,
         http_checks: bool = True,
-        timeout_seconds: Optional[int] = None,
     ) -> None:
         """
         Wait until the DC/OS Enterprise boot process has completed.
@@ -318,20 +315,18 @@ class Cluster(ContextDecorator):
                 fully ready. This is useful in cases where an HTTP connection
                 cannot be made to the cluster. For example, this is useful on
                 macOS without a VPN set up.
-            timeout_seconds: Optional timeout in seconds after which a DC/OS
-                start up is considered a failure.
 
         Raises:
-            ValueError: In case ``timeout_seconds`` is < 1.
             dcos_e2e.exceptions.DCOSTimeoutError: Raised if cluster components
-                did not become ready within the timeout boundary.
+                did not become ready within one hour.
         """
-        if timeout_seconds is not None and timeout_seconds < 1:
-            message = '``timeout_seconds`` must be ``None`` or >= 1.'
-            raise ValueError(message)
 
         @timeout_decorator.timeout(
-            timeout_seconds,
+            # will almost certainly not start up after this time.
+            #
+            # In the future we may want to increase this or make it
+            # customizable.
+            60 * 60,
             timeout_exception=DCOSTimeoutError,
         )
         def wait_for_dcos_ee_until_timeout() -> None:

--- a/src/dcos_e2e/cluster.py
+++ b/src/dcos_e2e/cluster.py
@@ -61,7 +61,7 @@ def _test_utils_wait_for_dcos(
     We want to ignore this error and use our own timeouts, so we wrap this in
     our own retried function.
     """
-    session.wait_for_dcos()
+    session.wait_for_dcos()  # type: ignore
 
 
 class Cluster(ContextDecorator):

--- a/src/dcos_e2e/cluster.py
+++ b/src/dcos_e2e/cluster.py
@@ -171,10 +171,8 @@ class Cluster(ContextDecorator):
                 a failure. The value 0 leads to an infinite timeout.
 
         Raises:
-            RetryError: Raised if cluster component did not become
-                healthy within time boundary set by ``dcos_test_utils``.
-            dcos_e2e.exceptions.DCOSTimeoutError: Raised if cluster component
-                did not become healthy within timeout boundary.
+            dcos_e2e.exceptions.DCOSTimeoutError: Raised if cluster components
+                did not become ready within timeout the boundary.
         """
 
         @timeout_decorator.timeout(
@@ -307,8 +305,8 @@ class Cluster(ContextDecorator):
                 a failure. The value 0 leads to an infinite timeout.
 
         Raises:
-            dcos_e2e.exceptions.DCOSTimeoutError: Raised if cluster component
-            did not become healthy within timeout boundary.
+            dcos_e2e.exceptions.DCOSTimeoutError: Raised if cluster components
+                did not become ready within the timeout boundary.
         """
 
         @timeout_decorator.timeout(
@@ -388,7 +386,7 @@ class Cluster(ContextDecorator):
 
             try:
                 enterprise_session.wait_for_dcos()
-            except retrying.RetryError:
+            except retrying.RetryError:  # pragma: no cover
                 raise DCOSTimeoutError
 
         wait_for_dcos_ee_until_timeout()

--- a/src/dcos_e2e/exceptions.py
+++ b/src/dcos_e2e/exceptions.py
@@ -1,0 +1,8 @@
+"""
+Custom exceptions.
+"""
+
+class DCOSTimeoutError(Exception):
+    """
+    Raise this in case of a timeout regarding DC/OS.
+    """

--- a/src/dcos_e2e/exceptions.py
+++ b/src/dcos_e2e/exceptions.py
@@ -5,5 +5,5 @@ Custom exceptions.
 
 class DCOSTimeoutError(Exception):
     """
-    Raise this in case of a timeout regarding DC/OS.
+    Raised if DC/OS does not become ready within a given time boundary.
     """

--- a/src/dcos_e2e/exceptions.py
+++ b/src/dcos_e2e/exceptions.py
@@ -2,6 +2,7 @@
 Custom exceptions.
 """
 
+
 class DCOSTimeoutError(Exception):
     """
     Raise this in case of a timeout regarding DC/OS.

--- a/tests/test_dcos_e2e/test_cluster.py
+++ b/tests/test_dcos_e2e/test_cluster.py
@@ -71,8 +71,14 @@ class TestIntegrationTests:
         """
         Exercise ``wait_for_dcos_oss`` code.
         """
-        with pytest.raises(DCOSTimeoutError):
-            cluster.wait_for_dcos_oss(timeout_seconds=1)
+        for timeout_seconds in [1, 2]:
+            time_before_waiting = time.monotonic()
+            with pytest.raises(DCOSTimeoutError):
+                cluster.wait_for_dcos_oss(timeout_seconds=timeout_seconds)
+            time_after_waiting = time.monotonic()
+            time_difference = time_after_waiting - time_before_waiting
+            maximum_acceptable = timeout_seconds + 0.1
+            assert timeout_seconds < time_difference < maximum_acceptable
 
         # We exercise the "http_checks=False" code here but we do not test
         # its functionality. It is a temporary measure while we wait for

--- a/tests/test_dcos_e2e/test_cluster.py
+++ b/tests/test_dcos_e2e/test_cluster.py
@@ -12,13 +12,12 @@ from textwrap import dedent
 from typing import Iterator, List
 
 import pytest
-import timeout_decorator
 from _pytest.logging import LogCaptureFixture
 from kazoo.client import KazooClient
 from py.path import local  # pylint: disable=no-name-in-module, import-error
 
 from dcos_e2e.backends import ClusterBackend
-from dcos_e2e.cluster import Cluster
+from dcos_e2e.cluster import Cluster, WaitForDCOSTimeoutError
 
 
 class TestIntegrationTests:
@@ -71,7 +70,7 @@ class TestIntegrationTests:
         """
         Exercise ``wait_for_dcos_oss`` code.
         """
-        with pytest.raises(timeout_decorator.timeout_decorator.TimeoutError):
+        with pytest.raises(WaitForDCOSTimeoutError):
             cluster.wait_for_dcos_oss(timeout=0)
 
         # We exercise the "http_checks=False" code here but we do not test

--- a/tests/test_dcos_e2e/test_cluster.py
+++ b/tests/test_dcos_e2e/test_cluster.py
@@ -6,6 +6,7 @@ long time to run.
 """
 
 import logging
+import time
 from pathlib import Path
 from subprocess import CalledProcessError
 from textwrap import dedent

--- a/tests/test_dcos_e2e/test_cluster.py
+++ b/tests/test_dcos_e2e/test_cluster.py
@@ -72,7 +72,7 @@ class TestIntegrationTests:
         Exercise ``wait_for_dcos_oss`` code.
         """
         with pytest.raises(DCOSTimeoutError):
-            cluster.wait_for_dcos_oss(timeout=1)
+            cluster.wait_for_dcos_oss(timeout_seconds=1)
 
         # We exercise the "http_checks=False" code here but we do not test
         # its functionality. It is a temporary measure while we wait for

--- a/tests/test_dcos_e2e/test_cluster.py
+++ b/tests/test_dcos_e2e/test_cluster.py
@@ -17,7 +17,8 @@ from kazoo.client import KazooClient
 from py.path import local  # pylint: disable=no-name-in-module, import-error
 
 from dcos_e2e.backends import ClusterBackend
-from dcos_e2e.cluster import Cluster, WaitForDCOSTimeoutError
+from dcos_e2e.cluster import Cluster
+from dcos_e2e.exceptions import DCOSTimeoutError
 
 
 class TestIntegrationTests:
@@ -70,7 +71,7 @@ class TestIntegrationTests:
         """
         Exercise ``wait_for_dcos_oss`` code.
         """
-        with pytest.raises(WaitForDCOSTimeoutError):
+        with pytest.raises(DCOSTimeoutError):
             cluster.wait_for_dcos_oss(timeout=0)
 
         # We exercise the "http_checks=False" code here but we do not test

--- a/tests/test_dcos_e2e/test_cluster.py
+++ b/tests/test_dcos_e2e/test_cluster.py
@@ -12,6 +12,7 @@ from textwrap import dedent
 from typing import Iterator, List
 
 import pytest
+import timeout_decorator
 from _pytest.logging import LogCaptureFixture
 from kazoo.client import KazooClient
 from py.path import local  # pylint: disable=no-name-in-module, import-error
@@ -70,6 +71,9 @@ class TestIntegrationTests:
         """
         Exercise ``wait_for_dcos_oss`` code.
         """
+        with pytest.raises(timeout_decorator.timeout_decorator.TimeoutError):
+            cluster.wait_for_dcos_oss(timeout=0)
+
         # We exercise the "http_checks=False" code here but we do not test
         # its functionality. It is a temporary measure while we wait for
         # more thorough dcos-checks.

--- a/tests/test_dcos_e2e/test_cluster.py
+++ b/tests/test_dcos_e2e/test_cluster.py
@@ -72,7 +72,7 @@ class TestIntegrationTests:
         Exercise ``wait_for_dcos_oss`` code.
         """
         with pytest.raises(DCOSTimeoutError):
-            cluster.wait_for_dcos_oss(timeout=0)
+            cluster.wait_for_dcos_oss(timeout=1)
 
         # We exercise the "http_checks=False" code here but we do not test
         # its functionality. It is a temporary measure while we wait for

--- a/tests/test_dcos_e2e/test_cluster.py
+++ b/tests/test_dcos_e2e/test_cluster.py
@@ -6,7 +6,6 @@ long time to run.
 """
 
 import logging
-import time
 from pathlib import Path
 from subprocess import CalledProcessError
 from textwrap import dedent
@@ -19,7 +18,6 @@ from py.path import local  # pylint: disable=no-name-in-module, import-error
 
 from dcos_e2e.backends import ClusterBackend
 from dcos_e2e.cluster import Cluster
-from dcos_e2e.exceptions import DCOSTimeoutError
 
 
 class TestIntegrationTests:
@@ -72,15 +70,6 @@ class TestIntegrationTests:
         """
         Exercise ``wait_for_dcos_oss`` code.
         """
-        for timeout_seconds in [1, 2]:
-            time_before_waiting = time.monotonic()
-            with pytest.raises(DCOSTimeoutError):
-                cluster.wait_for_dcos_oss(timeout_seconds=timeout_seconds)
-            time_after_waiting = time.monotonic()
-            time_difference = time_after_waiting - time_before_waiting
-            maximum_acceptable = timeout_seconds + 0.1
-            assert timeout_seconds < time_difference < maximum_acceptable
-
         # We exercise the "http_checks=False" code here but we do not test
         # its functionality. It is a temporary measure while we wait for
         # more thorough dcos-checks.

--- a/tests/test_dcos_e2e/test_enterprise.py
+++ b/tests/test_dcos_e2e/test_enterprise.py
@@ -12,7 +12,8 @@ import requests
 from passlib.hash import sha512_crypt
 
 from dcos_e2e.backends import ClusterBackend
-from dcos_e2e.cluster import Cluster, WaitForDCOSTimeoutError
+from dcos_e2e.cluster import Cluster
+from dcos_e2e.exceptions import DCOSTimeoutError
 from dcos_e2e.node import Role
 
 
@@ -397,7 +398,7 @@ class TestWaitForDCOS:
                 ip_detect_path=cluster_backend.ip_detect_path,
             )
             (master, ) = cluster.masters
-            with pytest.raises(WaitForDCOSTimeoutError):
+            with pytest.raises(DCOSTimeoutError):
                 cluster.wait_for_dcos_ee(timeout=0)
 
             cluster.wait_for_dcos_ee(

--- a/tests/test_dcos_e2e/test_enterprise.py
+++ b/tests/test_dcos_e2e/test_enterprise.py
@@ -7,11 +7,12 @@ import subprocess
 import uuid
 from pathlib import Path
 
+import pytest
 import requests
 from passlib.hash import sha512_crypt
 
 from dcos_e2e.backends import ClusterBackend
-from dcos_e2e.cluster import Cluster
+from dcos_e2e.cluster import Cluster, WaitForDCOSTimeoutError
 from dcos_e2e.node import Role
 
 
@@ -396,6 +397,9 @@ class TestWaitForDCOS:
                 ip_detect_path=cluster_backend.ip_detect_path,
             )
             (master, ) = cluster.masters
+            with pytest.raises(WaitForDCOSTimeoutError):
+                cluster.wait_for_dcos_ee(timeout=0)
+
             cluster.wait_for_dcos_ee(
                 superuser_username=superuser_username,
                 superuser_password=superuser_password,

--- a/tests/test_dcos_e2e/test_enterprise.py
+++ b/tests/test_dcos_e2e/test_enterprise.py
@@ -402,7 +402,7 @@ class TestWaitForDCOS:
                 cluster.wait_for_dcos_ee(
                     superuser_username=superuser_username,
                     superuser_password=superuser_password,
-                    timeout=1,
+                    timeout_seconds=1,
                 )
 
             cluster.wait_for_dcos_ee(

--- a/tests/test_dcos_e2e/test_enterprise.py
+++ b/tests/test_dcos_e2e/test_enterprise.py
@@ -4,17 +4,14 @@ Tests for using the test harness with a DC/OS Enterprise cluster.
 
 import json
 import subprocess
-import time
 import uuid
 from pathlib import Path
 
-import pytest
 import requests
 from passlib.hash import sha512_crypt
 
 from dcos_e2e.backends import ClusterBackend
 from dcos_e2e.cluster import Cluster
-from dcos_e2e.exceptions import DCOSTimeoutError
 from dcos_e2e.node import Role
 
 
@@ -399,19 +396,6 @@ class TestWaitForDCOS:
                 ip_detect_path=cluster_backend.ip_detect_path,
             )
             (master, ) = cluster.masters
-
-            for timeout_seconds in [1, 2]:
-                time_before_waiting = time.monotonic()
-                with pytest.raises(DCOSTimeoutError):
-                    cluster.wait_for_dcos_ee(
-                        superuser_username=superuser_username,
-                        superuser_password=superuser_password,
-                        timeout_seconds=timeout_seconds,
-                    )
-                time_after_waiting = time.monotonic()
-                time_difference = time_after_waiting - time_before_waiting
-                maximum_acceptable = timeout_seconds + 0.1
-                assert timeout_seconds < time_difference < maximum_acceptable
 
             cluster.wait_for_dcos_ee(
                 superuser_username=superuser_username,

--- a/tests/test_dcos_e2e/test_enterprise.py
+++ b/tests/test_dcos_e2e/test_enterprise.py
@@ -399,7 +399,11 @@ class TestWaitForDCOS:
             )
             (master, ) = cluster.masters
             with pytest.raises(DCOSTimeoutError):
-                cluster.wait_for_dcos_ee(timeout=0)
+                cluster.wait_for_dcos_ee(
+                    superuser_username=superuser_username,
+                    superuser_password=superuser_password,
+                    timeout=1,
+                )
 
             cluster.wait_for_dcos_ee(
                 superuser_username=superuser_username,


### PR DESCRIPTION
In order to no indefinitely wait for DC/OS to boot up, we need to limit the time spent waiting for all the components to come up.