### PR TITLE
Log subprocess output unicode characters where possible

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ Next
 
 - Add a ``dcos-docker doctor`` check for systemd.
 - Add a progress bar for ``doctor`` commands.
+- Log subprocess output unicode characters where possible.
 
 2018.11.09.1
 ------------

--- a/spelling_private_dict.txt
+++ b/spelling_private_dict.txt
@@ -14,6 +14,7 @@ badparameter
 bilal
 bootstrap
 breakpoint
+bytestring
 calledprocesserror
 centos
 cgroups

--- a/src/dcos_e2e/_common.py
+++ b/src/dcos_e2e/_common.py
@@ -43,6 +43,21 @@ def get_logger(name: str) -> logging.Logger:
 LOGGER = get_logger(__name__)
 
 
+def _safe_decode(output_bytes: bytes) -> str:
+    """
+    XXX
+    """
+    try:
+        return output_bytes.decode(
+            encoding='utf-8',
+            errors='strict',
+        )
+    except UnicodeDecodeError:
+        return output_bytes.decode(
+            encoding='ascii',
+            errors='backslashreplace',
+        )
+
 def run_subprocess(
     args: List[str],
     log_output_live: bool,
@@ -94,10 +109,7 @@ def run_subprocess(
                 stdout = b''
                 stderr = b''
                 for line in process.stdout:
-                    log_message = line.rstrip().decode(
-                        encoding='utf-8',
-                        errors='strict',
-                    )
+                    pass
                     LOGGER.debug(log_message)
                     stdout += line
                 # stderr/stdout are not readable anymore which usually means
@@ -121,10 +133,16 @@ def run_subprocess(
             else:
                 log = LOGGER.error
             for line in stderr.rstrip().split(b'\n'):
-                log_message = line.rstrip().decode(
-                    encoding='utf-8',
-                    errors='strict',
-                )
+                try:
+                    log_message = line.rstrip().decode(
+                        encoding='utf-8',
+                        errors='strict',
+                    )
+                except:
+                    log_message = line.rstrip().decode(
+                        encoding='ascii',
+                        errors='backslashreplace',
+                    )
                 log(log_message)
         if process.returncode != 0:
             raise subprocess.CalledProcessError(

--- a/src/dcos_e2e/_common.py
+++ b/src/dcos_e2e/_common.py
@@ -122,8 +122,8 @@ def run_subprocess(
                 log = LOGGER.error
             for line in stderr.rstrip().split(b'\n'):
                 log_message = line.rstrip().decode(
-                    encoding='ascii',
-                    errors='backslashreplace',
+                    encoding='utf-8',
+                    errors='strict',
                 )
                 log(log_message)
         if process.returncode != 0:

--- a/src/dcos_e2e/_common.py
+++ b/src/dcos_e2e/_common.py
@@ -45,7 +45,7 @@ LOGGER = get_logger(__name__)
 
 def _safe_decode(output_bytes: bytes) -> str:
     """
-    XXX
+    Decode a bytestring to Unicode with a safe fallback.
     """
     try:
         return output_bytes.decode(
@@ -109,7 +109,7 @@ def run_subprocess(
                 stdout = b''
                 stderr = b''
                 for line in process.stdout:
-                    pass
+                    log_message = _safe_decode(line.rstrip())
                     LOGGER.debug(log_message)
                     stdout += line
                 # stderr/stdout are not readable anymore which usually means
@@ -133,16 +133,7 @@ def run_subprocess(
             else:
                 log = LOGGER.error
             for line in stderr.rstrip().split(b'\n'):
-                try:
-                    log_message = line.rstrip().decode(
-                        encoding='utf-8',
-                        errors='strict',
-                    )
-                except:
-                    log_message = line.rstrip().decode(
-                        encoding='ascii',
-                        errors='backslashreplace',
-                    )
+                log_message = _safe_decode(line.rstrip())
                 log(log_message)
         if process.returncode != 0:
             raise subprocess.CalledProcessError(

--- a/src/dcos_e2e/_common.py
+++ b/src/dcos_e2e/_common.py
@@ -58,6 +58,7 @@ def _safe_decode(output_bytes: bytes) -> str:
             errors='backslashreplace',
         )
 
+
 def run_subprocess(
     args: List[str],
     log_output_live: bool,

--- a/src/dcos_e2e/_common.py
+++ b/src/dcos_e2e/_common.py
@@ -95,8 +95,8 @@ def run_subprocess(
                 stderr = b''
                 for line in process.stdout:
                     log_message = line.rstrip().decode(
-                        encoding='ascii',
-                        errors='backslashreplace',
+                        encoding='utf-8',
+                        errors='strict',
                     )
                     LOGGER.debug(log_message)
                     stdout += line

--- a/tests/test_dcos_e2e/test_node.py
+++ b/tests/test_dcos_e2e/test_node.py
@@ -15,7 +15,6 @@ from pathlib import Path
 from subprocess import CalledProcessError, TimeoutExpired
 from typing import Iterator
 
-import chardet
 import pytest
 from _pytest.capture import CaptureFixture
 from _pytest.fixtures import SubRequest
@@ -726,8 +725,16 @@ class TestOutput:
         assert result_log.levelno == logging.WARNING
         assert result_log.message == stderr_message
 
-    @pytest.mark.parametrize('stdout_message', [uuid.uuid4().hex, 'å'], ids=['ascii', 'unicode'])
-    @pytest.mark.parametrize('stderr_message', [uuid.uuid4().hex, 'å'], ids=['ascii', 'unicode'])
+    @pytest.mark.parametrize(
+        'stdout_message',
+        [uuid.uuid4().hex, 'å'],
+        ids=['ascii', 'unicode'],
+    )
+    @pytest.mark.parametrize(
+        'stderr_message',
+        [uuid.uuid4().hex, 'å'],
+        ids=['ascii', 'unicode'],
+    )
     def test_capture(
         self,
         caplog: LogCaptureFixture,
@@ -756,8 +763,16 @@ class TestOutput:
         assert result_log.levelno == logging.WARNING
         assert result_log.message == stderr_message
 
-    @pytest.mark.parametrize('stdout_message', [uuid.uuid4().hex, 'å'], ids=['ascii', 'unicode'])
-    @pytest.mark.parametrize('stderr_message', [uuid.uuid4().hex, 'å'], ids=['ascii', 'unicode'])
+    @pytest.mark.parametrize(
+        'stdout_message',
+        [uuid.uuid4().hex, 'å'],
+        ids=['ascii', 'unicode'],
+    )
+    @pytest.mark.parametrize(
+        'stderr_message',
+        [uuid.uuid4().hex, 'å'],
+        ids=['ascii', 'unicode'],
+    )
     def test_log_and_capture(
         self,
         caplog: LogCaptureFixture,
@@ -798,12 +813,14 @@ class TestOutput:
         dcos_node: Node,
     ) -> None:
         """
+        It is possible to see output of commands which output non-utf-8
+        bytes using ``output.LOG_AND_CAPTURE``.
         """
         # We expect that this will trigger a UnicodeDecodeError when run on a
         # node, if the result is meant to be decoded with utf-8.
         # It also is not so long that it will kill our terminal.
         args = ['head', '-c', '100', '/bin/cat']
-        result = dcos_node.run(args=args, output=Output.LOG_AND_CAPTURE)
+        dcos_node.run(args=args, output=Output.LOG_AND_CAPTURE)
         # We do not test the output, but we at least test its length for now.
         [log] = caplog.records
         assert len(log.message) >= 100
@@ -814,14 +831,16 @@ class TestOutput:
         dcos_node: Node,
     ) -> None:
         """
+        It is possible to capture output of commands which output non-utf-8
+        bytes using ``output.CAPTURE``.
         """
         # We expect that this will trigger a UnicodeDecodeError when run on a
         # node, if the result is meant to be decoded with utf-8.
         # It also is not so long that it will kill our terminal.
         args = ['head', '-c', '100', '/bin/cat']
         args = ['>&2'] + args
-        result = dcos_node.run(args=args, output=Output.CAPTURE, shell=True)
-        args_log, result_log = caplog.records
+        dcos_node.run(args=args, output=Output.CAPTURE, shell=True)
+        _, result_log = caplog.records
         # We do not test the output, but we at least test its length for now.
         assert len(result_log.message) >= 100
 

--- a/tests/test_dcos_e2e/test_node.py
+++ b/tests/test_dcos_e2e/test_node.py
@@ -791,6 +791,9 @@ class TestOutput:
         messages = set([first_log.message, second_log.message])
         assert messages == expected_messages
 
+    def test_not_utf_8():
+        pass
+
     def test_no_capture(
         self,
         capfd: CaptureFixture,

--- a/tests/test_dcos_e2e/test_node.py
+++ b/tests/test_dcos_e2e/test_node.py
@@ -725,10 +725,14 @@ class TestOutput:
         assert result_log.levelno == logging.WARNING
         assert result_log.message == stderr_message
 
+    @pytest.mark.parametrize('stdout_message', [uuid.uuid4().hex, 'å'], ids=['ascii', 'unicode'])
+    @pytest.mark.parametrize('stderr_message', [uuid.uuid4().hex, 'å'], ids=['ascii', 'unicode'])
     def test_capture(
         self,
         caplog: LogCaptureFixture,
         dcos_node: Node,
+        stdout_message: str,
+        stderr_message: str,
     ) -> None:
         """
         When given ``Output.CAPTURE``, stderr and stdout are captured in the
@@ -736,8 +740,6 @@ class TestOutput:
 
         stderr is logged.
         """
-        stdout_message = uuid.uuid4().hex
-        stderr_message = uuid.uuid4().hex
         args = ['echo', stdout_message, '&&', '>&2', 'echo', stderr_message]
         result = dcos_node.run(args=args, output=Output.CAPTURE, shell=True)
         assert result.stdout.strip().decode() == stdout_message

--- a/tests/test_dcos_e2e/test_node.py
+++ b/tests/test_dcos_e2e/test_node.py
@@ -753,10 +753,14 @@ class TestOutput:
         assert result_log.levelno == logging.WARNING
         assert result_log.message == stderr_message
 
+    @pytest.mark.parametrize('stdout_message', [uuid.uuid4().hex, 'å'], ids=['ascii', 'unicode'])
+    @pytest.mark.parametrize('stderr_message', [uuid.uuid4().hex, 'å'], ids=['ascii', 'unicode'])
     def test_log_and_capture(
         self,
         caplog: LogCaptureFixture,
         dcos_node: Node,
+        stdout_message: str,
+        stderr_message: str,
     ) -> None:
         """
         When given ``Output.LOG_AND_CAPTURE``, stderr and stdout are captured
@@ -764,8 +768,6 @@ class TestOutput:
 
         stdout and stderr are logged.
         """
-        stdout_message = uuid.uuid4().hex
-        stderr_message = uuid.uuid4().hex
         args = ['echo', stdout_message, '&&', '>&2', 'echo', stderr_message]
         result = dcos_node.run(
             args=args,


### PR DESCRIPTION
This was based on code and ideas from @jongiddy .
See https://jira.mesosphere.com/browse/DCOS_OSS-4482.