### PR TITLE
Add postinstall Python steps to avoid issue with setuptools missing

### DIFF
--- a/docs/cli/source/cli-homebrew.rst
+++ b/docs/cli/source/cli-homebrew.rst
@@ -6,12 +6,16 @@ Then install the latest stable version:
 
 .. substitution-prompt:: bash
 
+    brew install python
+    brew postinstall python
     brew install https://raw.githubusercontent.com/|github-owner|/|github-repository|/master/|brewfile-stem|.rb
 
 To upgrade from an older version, run the following command:
 
 .. substitution-prompt:: bash
 
+    brew install python
+    brew postinstall python
     brew upgrade https://raw.githubusercontent.com/|github-owner|/|github-repository|/master/|brewfile-stem|.rb
 
 Or the latest ``master``:
@@ -20,6 +24,8 @@ Homebrew installs the dependencies for the latest released version and so instal
 
 .. substitution-prompt:: bash
 
+    brew install python
+    brew postinstall python
     brew install --HEAD https://raw.githubusercontent.com/|github-owner|/|github-repository|/master/|brewfile-stem|.rb
 
 .. _Homebrew: https://brew.sh


### PR DESCRIPTION
See https://stackoverflow.com/questions/53966725/macos-how-do-i-install-minidc-os-error-no-module-name-setuptools for an example of what this attempts to fix.

```
bash-3.2$ brew install https://raw.githubusercontent.com/dcos/dcos-e2e/master/minidcos.rb
Updating Homebrew...
Ignoring path homebrew-cask/
To restore the stashed changes to /usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask run:
  'cd /usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask && git stash pop'
==> Auto-updated Homebrew!
Updated 2 taps (homebrew/core and homebrew/cask).
==> Updated Formulae
binaryen                 erlang                   exploitdb                fn                       git-quick-stats          goreleaser               libcerf                  minio

######################################################################## 100.0%
==> Downloading https://codeload.github.com/dcos/dcos-e2e/legacy.tar.gz/2018.12.10.0
Already downloaded: /Users/admin/Library/Caches/Homebrew/downloads/4f4e8602babc8445ee074a81a6e032ae53050886dd9e12c8529a684dd5e45c8e--dcos-dcos-e2e-2018.12.10.0-0-g3cedccc.tar.gz
Warning: Cannot verify integrity of 4f4e8602babc8445ee074a81a6e032ae53050886dd9e12c8529a684dd5e45c8e--dcos-dcos-e2e-2018.12.10.0-0-g3cedccc.tar.gz
A checksum was not provided for this resource
For your reference the SHA256 is: 20cf5dd26ed99cd9930e47c77d2aff81aa0b0137aeb4128684165b09312a66e5
==> Downloading https://files.pythonhosted.org/packages/4e/8b/75469c270ac544265f0020aa7c4ea925c5284b23e445cf3aa8b99f662690/virtualenv-16.1.0.tar.gz
Already downloaded: /Users/admin/Library/Caches/Homebrew/downloads/bda8bcde19a275fd9c84a7ec957593976e90dfd0e461a87f5698f1d2286c0197--virtualenv-16.1.0.tar.gz
==> python3 -c import setuptools... --no-user-cfg install --prefix=/private/tmp/minidcos--homebrew-virtualenv-20181228-35978-r206u1/target --install-scripts=/private/tmp/minidcos--homebrew-virtualenv
Last 15 lines from /Users/admin/Library/Logs/Homebrew/minidcos/01.python3:
-c
import setuptools, tokenize
__file__ = 'setup.py'
exec(compile(getattr(tokenize, 'open', open)(__file__).read()
  .replace('\r\n', '\n'), __file__, 'exec'))
--no-user-cfg
install
--prefix=/private/tmp/minidcos--homebrew-virtualenv-20181228-35978-r206u1/target
--install-scripts=/private/tmp/minidcos--homebrew-virtualenv-20181228-35978-r206u1/target/bin
--single-version-externally-managed
--record=installed.txt

Traceback (most recent call last):
  File "<string>", line 1, in <module>
ModuleNotFoundError: No module named 'setuptools'

Do not report this issue to Homebrew/brew or Homebrew/core!
```