### PR TITLE
Fix exception handling in `DockerLoopbackVolume`

### DIFF
--- a/src/dcos_e2e/docker_utils/__init__.py
+++ b/src/dcos_e2e/docker_utils/__init__.py
@@ -10,7 +10,7 @@ import docker
 from dcos_e2e.backends import Docker
 
 
-class DockerLoopbackVolume():
+class DockerLoopbackVolume:
     """
     A loopback device sidecar, created in a Docker container.
     """

--- a/src/dcos_e2e/docker_utils/__init__.py
+++ b/src/dcos_e2e/docker_utils/__init__.py
@@ -120,4 +120,4 @@ class DockerLoopbackVolume:
         On exiting, destroy the loopback volume.
         """
         DockerLoopbackVolume.destroy(self._container)
-        return True
+        return False

--- a/tests/test_dcos_e2e/docker_utils/test_loopback.py
+++ b/tests/test_dcos_e2e/docker_utils/test_loopback.py
@@ -21,7 +21,7 @@ class TestDockerLoopbackVolume:
             privileged=True,
             detach=True,
             image='centos:7',
-            entrypoint =['/bin/sleep', 'infinity'],
+            entrypoint=['/bin/sleep', 'infinity'],
         )
         with DockerLoopbackVolume(size_megabytes=size_megabytes) as device:
             container.start()

--- a/tests/test_dcos_e2e/docker_utils/test_loopback.py
+++ b/tests/test_dcos_e2e/docker_utils/test_loopback.py
@@ -34,16 +34,15 @@ class TestDockerLoopbackVolume:
                 assert exit_code == 0, device.path + ': ' + output.decode()
 
                 block_device_has_right_size = [
-                    'stat',
-                    '-f',
-                    '"%z"',
+                    'blockdev',
+                    '--getsize64',
                     device.path,
                 ]
                 exit_code, output = new_container.exec_run(
                     cmd=block_device_has_right_size,
                 )
                 assert exit_code == 0, device.path + ': ' + output.decode()
-                assert output == '1048576'
+                assert output == str(1024 * 1024)
             finally:
                 new_container.stop()
                 new_container.remove()

--- a/tests/test_dcos_e2e/docker_utils/test_loopback.py
+++ b/tests/test_dcos_e2e/docker_utils/test_loopback.py
@@ -34,13 +34,14 @@ class TestDockerLoopbackVolume:
             size_exit_code, size_output = container.exec_run(
                 cmd=block_device_has_right_size,
             )
-            container.stop()
-            container.remove()
 
-            assert exists_exit_code == 0, path + ': ' + exists_output.decode()
-            assert size_exit_code == 0, path + ': ' + size_output.decode()
-            expected_output = str(1024 * 1024 * size_megabytes)
-            assert size_output.decode().strip() == expected_output
+        container.stop()
+        container.remove()
+
+        assert exists_exit_code == 0, path + ': ' + exists_output.decode()
+        assert size_exit_code == 0, path + ': ' + size_output.decode()
+        expected_output = str(1024 * 1024 * size_megabytes)
+        assert size_output.decode().strip() == expected_output
 
     def test_labels(self) -> None:
         """

--- a/tests/test_dcos_e2e/docker_utils/test_loopback.py
+++ b/tests/test_dcos_e2e/docker_utils/test_loopback.py
@@ -17,13 +17,13 @@ class TestDockerLoopbackVolume:
         A block device is created which is accessible to multiple containers.
         """
         client = docker.from_env(version='auto')
+        container = client.containers.create(
+            privileged=True,
+            detach=True,
+            image='centos:7',
+            entrypoint =['/bin/sleep', 'infinity'],
+        )
         with DockerLoopbackVolume(size_megabytes=size_megabytes) as device:
-            container = client.containers.create(
-                privileged=True,
-                detach=True,
-                image='centos:7',
-                entrypoint =['/bin/sleep', 'infinity'],
-            )
             container.start()
             path = device.path
             block_device_exists = ['lsblk', path]

--- a/tests/test_dcos_e2e/docker_utils/test_loopback.py
+++ b/tests/test_dcos_e2e/docker_utils/test_loopback.py
@@ -22,6 +22,7 @@ class TestDockerLoopbackVolume:
                 privileged=True,
                 detach=True,
                 image='centos:7',
+                entrypoint =['/bin/sleep', 'infinity'],
             )
             new_container.start()
 

--- a/tests/test_dcos_e2e/docker_utils/test_loopback.py
+++ b/tests/test_dcos_e2e/docker_utils/test_loopback.py
@@ -11,12 +11,12 @@ class TestDockerLoopbackVolume:
     Tests for setting device mapping on master or agent Docker containers.
     """
 
-    def test_loopback(self) -> None:
+    @pytest.mark.parametrize('size_megabytes', [1, 2])
+    def test_loopback(self, size_megabytes: int) -> None:
         """
         A block device is created which is accessible to multiple containers.
         """
         client = docker.from_env(version='auto')
-        size_megabytes = 1
         with DockerLoopbackVolume(size_megabytes=size_megabytes) as device:
             container = client.containers.create(
                 privileged=True,

--- a/tests/test_dcos_e2e/docker_utils/test_loopback.py
+++ b/tests/test_dcos_e2e/docker_utils/test_loopback.py
@@ -42,7 +42,7 @@ class TestDockerLoopbackVolume:
                     cmd=block_device_has_right_size,
                 )
                 assert exit_code == 0, device.path + ': ' + output.decode()
-                assert output == str(1024 * 1024)
+                assert output.decode().strip() == str(1024 * 1024)
             finally:
                 new_container.stop()
                 new_container.remove()


### PR DESCRIPTION
cc @nfnt 

Our nightly builder showed that we had missing coverage in the changed test.
What was happening was that an ``AssertionError`` was being raised, but our `__exit__` had `return True` which caught exceptions.

When this was changed, I saw various errors, in order:

* The container did not exist when the `exec` commands were run - I made a `sleep infinity` entrypoint
* The `stat` command we had used `-f` for format - but this should be `-c --format`
* The `stat` command format was not what we wanted, so I chose to use `blockdev`

I since reformatted the test to remove the `try... finally` block.