### PR TITLE
Remove requirement for LANG and LC_ALL

### DIFF
--- a/admin/binaries.py
+++ b/admin/binaries.py
@@ -42,7 +42,7 @@ def make_linux_binaries(repo_root: Path) -> Set[Path]:
     cmd = 'bash -c "{cmd}"'.format(cmd=' '.join(cmd_in_container))
 
     container = client.containers.run(
-        image='python:3.6',
+        image='python:3.7',
         mounts=[code_mount],
         command=cmd,
         working_dir=target_dir,

--- a/admin/homebrew.py
+++ b/admin/homebrew.py
@@ -91,8 +91,6 @@ def get_homebrew_formula(
           end
 
           test do
-              ENV["LC_ALL"] = "en_US.utf-8"
-              ENV["LANG"] = "en_US.utf-8"
               system "#{{bin}}/dcos_docker", "--help"
           end
         end

--- a/tests/test_admin/test_binaries.py
+++ b/tests/test_admin/test_binaries.py
@@ -42,6 +42,12 @@ def test_linux_binaries() -> None:
 
     for remote_path in remote_paths:
         cmd_in_container = [
+            'unset',
+            'LANG',
+            '&&',
+            'unset',
+            'LC_ALL',
+            '&&',
             'chmod',
             '+x',
             str(remote_path),

--- a/tests/test_admin/test_binaries.py
+++ b/tests/test_admin/test_binaries.py
@@ -41,6 +41,9 @@ def test_linux_binaries() -> None:
     client = docker.from_env(version='auto')
 
     for remote_path in remote_paths:
+        # Unset LANG and LC_ALL to show that these are not necessary for the
+        # CLI to run.
+        # This was a problem when the binaries were built with Python < 3.7.
         cmd_in_container = [
             'unset',
             'LANG',


### PR DESCRIPTION
This is no longer an issue in Python 3.7.