### PR TITLE
Use correct ip address in ClusterContainers to_node

### DIFF
--- a/src/dcos_e2e_cli/dcos_docker/commands/_common.py
+++ b/src/dcos_e2e_cli/dcos_docker/commands/_common.py
@@ -101,7 +101,11 @@ class ClusterContainers(ClusterRepresentation):
         Return the ``Node`` that is represented by a given ``container``.
         """
         container = node_representation
-        address = IPv4Address(container.attrs['NetworkSettings']['IPAddress'])
+        networks = container.attrs['NetworkSettings']['Networks']
+        network_name = 'bridge'
+        if len(networks) != 1:
+            [network_name] = list(networks.keys() - set(['bridge']))
+        address = IPv4Address(networks[network_name]['IPAddress'])
         return Node(
             public_ip_address=address,
             private_ip_address=address,


### PR DESCRIPTION
When creating a minidcos docker cluster with a custom docker network the
ip address of the docker0 network is used and not the one of the custom
docker network. Looks like this got introduced by
540b4e16461d27109cc7d8ed37d31f8eecd86d64 (before that it worked just
fine). Reuse the code from DockerCluster _nodes to fix this.