### PR TITLE
Remove  command from the examples, as it's not implemented at the moment

### DIFF
--- a/docs/cli/source/dcos-aws-cli.rst
+++ b/docs/cli/source/dcos-aws-cli.rst
@@ -20,7 +20,6 @@ Install the CLI (see :doc:`install-cli`),  then create and manage a cluster:
    # Get onto a node
    $ minidcos aws run bash
    [master-0]# exit
-   $ minidcos aws destroy
 
 Each of these and more are described in detail below.
 


### PR DESCRIPTION
This PR removes `minidcos aws destroy` command from the examples, since it's not implemented yet.