### PR TITLE
Get rid of deprecated --offline flag

### DIFF
--- a/src/dcos_e2e/backends/_docker/__init__.py
+++ b/src/dcos_e2e/backends/_docker/__init__.py
@@ -572,7 +572,6 @@ class DockerCluster(ClusterManager):
         genconf_args = [
             'bash',
             str(dcos_installer),
-            '--offline',
             '-v',
             '--genconf',
         ]

--- a/src/dcos_e2e/node.py
+++ b/src/dcos_e2e/node.py
@@ -229,7 +229,6 @@ class Node:
             '&&',
             'bash',
             str(remote_dcos_installer),
-            '--offline',
             '-v',
             '--genconf',
         ]


### PR DESCRIPTION
This flag is deprecated and can just be removed without losing any
functionality.