### PR TITLE
Change default memory allocation via library to be consistent with CLI

### DIFF
--- a/src/dcos_e2e/backends/_vagrant/__init__.py
+++ b/src/dcos_e2e/backends/_vagrant/__init__.py
@@ -24,7 +24,7 @@ class Vagrant(ClusterBackend):
         self,
         virtualbox_description: str = '',
         workspace_dir: Optional[Path] = None,
-        vm_memory_mb: int = 4096,
+        vm_memory_mb: int = 2048,
     ) -> None:
         """
         Create a configuration for a Vagrant cluster backend.

--- a/src/dcos_e2e_cli/dcos_vagrant/commands/_common.py
+++ b/src/dcos_e2e_cli/dcos_vagrant/commands/_common.py
@@ -266,7 +266,7 @@ class ClusterVMs(ClusterRepresentation):
             'PATH': os.environ['PATH'],
             'VM_NAMES': ','.join(list(vm_names)),
             'VM_DESCRIPTION': description,
-            'VM_MEMORY': '4096',
+            'VM_MEMORY': '2048',
         }
 
         [vagrant_root_parent] = [


### PR DESCRIPTION
The library allocates 4096MB by default to VMs instantiated via Vagrant.  This commit drops that to 2048MB so that it's consistent with the behaviour of the CLI.