### PR TITLE
Add --aws-instance-type option

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ Next
 * Added options to choose the amount of memory given to each VM.
 * Fixed a bug which prevented ``minidcos vagrant`` from working when a VM existed with a space in the name.
 * Fixed a bug which prevented ``minidcos vagrant`` from working in some situations when the ``$HOME`` environment variable is not set.
+* Added option to choose AWS instance type.
 
 2019.05.24.1
 ------------

--- a/docs/library/source/aws-backend.rst
+++ b/docs/library/source/aws-backend.rst
@@ -18,6 +18,12 @@ This is because the installation method employs a bootstrap node that directly d
 The :py:attr:`~dcos_e2e.node.Node.private_ip_address` refers to the internal network of the AWS stack which is also used by DC/OS internally.
 The :py:attr:`~dcos_e2e.node.Node.public_ip_address` allows for reaching AWS EC2 instances from the outside e.g. from the ``dcos-e2e`` testing environment.
 
+AWS Instance Types
+------------------
+
+When launching a cluster with Amazon Web Services there are a number of different instance types to choose from using :paramref:`~dcos_e2e.backends.AWS.aws_instance_type`.
+It is recommended to use ``m4.large`` to keep the cost low, but ``m5.2xlarge`` may be required for some services, such as MKE.
+
 AWS Regions
 -----------
 

--- a/src/dcos_e2e_cli/dcos_aws/commands/_options.py
+++ b/src/dcos_e2e_cli/dcos_aws/commands/_options.py
@@ -9,22 +9,8 @@ import click
 from ._common import LINUX_DISTRIBUTIONS
 
 
-def aws_region_option(command: Callable[..., None]) -> Callable[..., None]:
-    """
-    An option decorator for AWS regions.
-    """
-    function = click.option(
-        '--aws-region',
-        type=str,
-        default='us-west-2',
-        show_default=True,
-        help='The AWS region to use.',
-    )(command)  # type: Callable[..., None]
-    return function
-
-
 def aws_instance_type_option(
-    command: Callable[..., None]
+    command: Callable[..., None],
 ) -> Callable[..., None]:
     """
     An option decorator for AWS instance types.
@@ -35,6 +21,20 @@ def aws_instance_type_option(
         default='m4.large',
         show_default=True,
         help='The AWS instance type to use.',
+    )(command)  # type: Callable[..., None]
+    return function
+
+
+def aws_region_option(command: Callable[..., None]) -> Callable[..., None]:
+    """
+    An option decorator for AWS regions.
+    """
+    function = click.option(
+        '--aws-region',
+        type=str,
+        default='us-west-2',
+        show_default=True,
+        help='The AWS region to use.',
     )(command)  # type: Callable[..., None]
     return function
 

--- a/src/dcos_e2e_cli/dcos_aws/commands/_options.py
+++ b/src/dcos_e2e_cli/dcos_aws/commands/_options.py
@@ -9,9 +9,8 @@ import click
 from ._common import LINUX_DISTRIBUTIONS
 
 
-def aws_instance_type_option(
-    command: Callable[..., None],
-) -> Callable[..., None]:
+def aws_instance_type_option(command: Callable[..., None],
+                             ) -> Callable[..., None]:
     """
     An option decorator for AWS instance types.
     """

--- a/src/dcos_e2e_cli/dcos_aws/commands/_options.py
+++ b/src/dcos_e2e_cli/dcos_aws/commands/_options.py
@@ -23,6 +23,22 @@ def aws_region_option(command: Callable[..., None]) -> Callable[..., None]:
     return function
 
 
+def aws_instance_type_option(
+    command: Callable[..., None]
+) -> Callable[..., None]:
+    """
+    An option decorator for AWS instance types.
+    """
+    function = click.option(
+        '--aws-instance-type',
+        type=str,
+        default='m4.large',
+        show_default=True,
+        help='The AWS instance type to use.',
+    )(command)  # type: Callable[..., None]
+    return function
+
+
 def linux_distribution_option(command: Callable[..., None],
                               ) -> Callable[..., None]:
     """

--- a/src/dcos_e2e_cli/dcos_aws/commands/create.py
+++ b/src/dcos_e2e_cli/dcos_aws/commands/create.py
@@ -77,8 +77,8 @@ from .wait import wait
 @agents_option
 @extra_config_option
 @public_agents_option
-@aws_region_option
 @aws_instance_type_option
+@aws_region_option
 @linux_distribution_option
 @workspace_dir_option
 @license_key_option
@@ -101,8 +101,8 @@ def create(
     license_key: Optional[Path],
     security_mode: Optional[str],
     copy_to_master: List[Tuple[Path, Path]],
-    aws_region: str,
     aws_instance_type: str,
+    aws_region: str,
     linux_distribution: str,
     cluster_id: str,
     enable_selinux_enforcing: bool,

--- a/src/dcos_e2e_cli/dcos_aws/commands/create.py
+++ b/src/dcos_e2e_cli/dcos_aws/commands/create.py
@@ -55,9 +55,9 @@ from ._common import (
 )
 from ._custom_tag import custom_tag_option
 from ._options import (
-    aws_region_option,
     aws_instance_type_option,
-    linux_distribution_option
+    aws_region_option,
+    linux_distribution_option,
 )
 from ._variant import variant_option
 from ._wait_for_dcos import wait_for_dcos_option

--- a/src/dcos_e2e_cli/dcos_aws/commands/create.py
+++ b/src/dcos_e2e_cli/dcos_aws/commands/create.py
@@ -54,7 +54,11 @@ from ._common import (
     existing_cluster_ids,
 )
 from ._custom_tag import custom_tag_option
-from ._options import aws_region_option, linux_distribution_option
+from ._options import (
+    aws_region_option,
+    aws_instance_type_option,
+    linux_distribution_option
+)
 from ._variant import variant_option
 from ._wait_for_dcos import wait_for_dcos_option
 from .doctor import doctor
@@ -74,6 +78,7 @@ from .wait import wait
 @extra_config_option
 @public_agents_option
 @aws_region_option
+@aws_instance_type_option
 @linux_distribution_option
 @workspace_dir_option
 @license_key_option
@@ -97,6 +102,7 @@ def create(
     security_mode: Optional[str],
     copy_to_master: List[Tuple[Path, Path]],
     aws_region: str,
+    aws_instance_type: str,
     linux_distribution: str,
     cluster_id: str,
     enable_selinux_enforcing: bool,
@@ -163,6 +169,7 @@ def create(
     cluster_backend = AWS(
         aws_key_pair=(key_name, private_key_path),
         workspace_dir=workspace_dir,
+        aws_instance_type=aws_instance_type,
         aws_region=aws_region,
         linux_distribution=distribution,
         ec2_instance_tags=cluster_tags,

--- a/src/dcos_e2e_cli/dcos_aws/commands/provision.py
+++ b/src/dcos_e2e_cli/dcos_aws/commands/provision.py
@@ -44,7 +44,11 @@ from ._common import (
     existing_cluster_ids,
 )
 from ._custom_tag import custom_tag_option
-from ._options import aws_region_option, linux_distribution_option
+from ._options import (
+    aws_instance_type_option,
+    aws_region_option,
+    linux_distribution_option,
+)
 from .doctor import doctor
 
 
@@ -53,6 +57,7 @@ from .doctor import doctor
 @masters_option
 @agents_option
 @public_agents_option
+@aws_instance_type_option
 @aws_region_option
 @linux_distribution_option
 @workspace_dir_option
@@ -68,6 +73,7 @@ def provision(
     public_agents: int,
     workspace_dir: Path,
     copy_to_master: List[Tuple[Path, Path]],
+    aws_instance_type: str,
     aws_region: str,
     linux_distribution: str,
     cluster_id: str,
@@ -126,6 +132,7 @@ def provision(
     cluster_backend = AWS(
         aws_key_pair=(key_name, private_key_path),
         workspace_dir=workspace_dir,
+        aws_instance_type=aws_instance_type,
         aws_region=aws_region,
         linux_distribution=distribution,
         ec2_instance_tags=cluster_tags,

--- a/tests/test_cli/test_dcos_aws/help_outputs/dcos-aws-create.txt
+++ b/tests/test_cli/test_dcos_aws/help_outputs/dcos-aws-create.txt
@@ -45,6 +45,8 @@ Options:
                                   configuration.
   --public-agents INTEGER         The number of public agent nodes.  [default:
                                   1]
+  --aws-instance-type TEXT        The AWS instance type to use.  [default:
+                                  m4.large]
   --aws-region TEXT               The AWS region to use.  [default: us-west-2]
   --linux-distribution [centos-7|coreos|rhel-7]
                                   The Linux distribution to use on the nodes.

--- a/tests/test_cli/test_dcos_aws/help_outputs/dcos-aws-provision.txt
+++ b/tests/test_cli/test_dcos_aws/help_outputs/dcos-aws-provision.txt
@@ -9,6 +9,8 @@ Options:
   --agents INTEGER                The number of agent nodes.  [default: 1]
   --public-agents INTEGER         The number of public agent nodes.  [default:
                                   1]
+  --aws-instance-type TEXT        The AWS instance type to use.  [default:
+                                  m4.large]
   --aws-region TEXT               The AWS region to use.  [default: us-west-2]
   --linux-distribution [centos-7|coreos|rhel-7]
                                   The Linux distribution to use on the nodes.


### PR DESCRIPTION
Allow the AWS instance type to be specified as an option