### PR TITLE
homebrew: remove workaround

### DIFF
--- a/minidcos.rb
+++ b/minidcos.rb
@@ -414,25 +414,6 @@ class Minidcos < Formula
 
 
   def install
-    # Ideally this whole section would be "virtualenv_install_with_resources".
-    # However, we work around https://github.com/Homebrew/brew/issues/6200 -
-    # that Homebrew uses `--no-binary :all:` which is incompatible with some
-    # modern versions of `pip` which suffer the bug
-    # https://github.com/pypa/pip/issues/6222.
-    wanted = %w[python python@2 python2 python3 python@3 pypy pypy3].select { |py| needs_python?(py) }
-    raise FormulaAmbiguousPythonError, self if wanted.size > 1
-
-    python = wanted.first || "python2.7"
-    python = "python3" if python == "python"
-    venv = virtualenv_create(libexec, python.delete("@"))
-    venv.instance_variable_get(:@formula).system venv.instance_variable_get(:@venv_root)/"bin/pip", "install",
-                    "-v", "--no-deps",
-                    "--ignore-installed",
-                    "--upgrade",
-                    "--force-reinstall",
-                    "pip<19"
-    venv.pip_install resources
-    venv.pip_install_and_link buildpath
-    venv
+    virtualenv_install_with_resources
   end
 end


### PR DESCRIPTION
The issue in https://github.com/pypa/pip/issues/6222 ahs been fixed in
pip. The install now works without the workaround.

With the workaround in place pip was having issues:

```bash
$ brew install https://raw.githubusercontent.com/dcos/dcos-e2e/master/minidcos.rb
######################################################################## 100.0%
==> Downloading https://codeload.github.com/dcos/dcos-e2e/legacy.tar.gz/2019.10.11.0
Already downloaded: /Users/jkoelker/Library/Caches/Homebrew/downloads/c5bf411e3bd276128dc291662bb45dd7bef476edf6fee0d9ba003cdc1d44ce6e--dcos-dcos-e2e-2019.10.11.0-0-gb52ef9a.tar.gz
Warning: Cannot verify integrity of c5bf411e3bd276128dc291662bb45dd7bef476edf6fee0d9ba003cdc1d44ce6e--dcos-dcos-e2e-2019.10.11.0-0-gb52ef9a.tar.gz
A checksum was not provided for this resource.
For your reference the SHA-256 is: fa39dc5667011fdd68837d0b84669193c7695ba9eff98f687ddbc9c61187331d
==> Downloading https://files.pythonhosted.org/packages/11/74/2c151a13ef41ab9fb43b3c4ff9e788e0496ed7923b2078d42cab30622bdf/virt
Already downloaded: /Users/jkoelker/Library/Caches/Homebrew/downloads/507d2087bf24df82641b681a5fe4da778ef50ebe819a86ea1b584f70788f0f63--virtualenv-16.7.4.tar.gz
==> python3 -c import setuptools... --no-user-cfg install --prefix=/private/tmp/minidcos--homebrew-virtualenv-20200205-2541-1d0
==> python3 -s /private/tmp/minidcos--homebrew-virtualenv-20200205-2541-1d05kt3/target/bin/virtualenv -p python3 /usr/local/Cel
==> /usr/local/Cellar/minidcos/2019.10.11.0/libexec/bin/pip install -v --no-deps --ignore-installed --upgrade --force-reinstall
==> Downloading https://files.pythonhosted.org/packages/75/e2/c44b5e8d99544a2e21aace5f8390c6f3dbf8a952f0453779075ffafafc80/adal
Already downloaded: /Users/jkoelker/Library/Caches/Homebrew/downloads/b852fb0bf229f97820a9cd5ca378547c21b5fd1b53a4d7d1efcac26c1e323f1f--adal-1.2.2.tar.gz
==> /usr/local/Cellar/minidcos/2019.10.11.0/libexec/bin/pip install -v --no-deps --no-binary :all: --ignore-installed /private/
Last 15 lines from /Users/jkoelker/Library/Logs/Homebrew/minidcos/04.pip:
  File "/usr/local/Cellar/minidcos/2019.10.11.0/libexec/bin/pip", line 5, in <module>
    from pip._internal import main
  File "/usr/local/Cellar/minidcos/2019.10.11.0/libexec/lib/python3.7/site-packages/pip/_internal/__init__.py", line 40, in <module>
    from pip._internal.cli.autocompletion import autocomplete
  File "/usr/local/Cellar/minidcos/2019.10.11.0/libexec/lib/python3.7/site-packages/pip/_internal/cli/autocompletion.py", line 8, in <module>
    from pip._internal.cli.main_parser import create_main_parser
  File "/usr/local/Cellar/minidcos/2019.10.11.0/libexec/lib/python3.7/site-packages/pip/_internal/cli/main_parser.py", line 12, in <module>
    from pip._internal.commands import (
  File "/usr/local/Cellar/minidcos/2019.10.11.0/libexec/lib/python3.7/site-packages/pip/_internal/commands/__init__.py", line 6, in <module>
    from pip._internal.commands.completion import CompletionCommand
  File "/usr/local/Cellar/minidcos/2019.10.11.0/libexec/lib/python3.7/site-packages/pip/_internal/commands/completion.py", line 6, in <module>
    from pip._internal.cli.base_command import Command
  File "/usr/local/Cellar/minidcos/2019.10.11.0/libexec/lib/python3.7/site-packages/pip/_internal/cli/base_command.py", line 23, in <module>
    from pip._internal.index import PackageFinder
ImportError: cannot import name 'PackageFinder' from 'pip._internal.index' (/usr/local/Cellar/minidcos/2019.10.11.0/libexec/lib/python3.7/site-packages/pip/_internal/index/__init__.py)

Do not report this issue to Homebrew/brew or Homebrew/core!
```

Removing the workaround allowed it to install and work as expected.