### PR TITLE
Update default Vagrant box to dcos-vagrant-box 0.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,6 +71,7 @@ env:
   - CI_PATTERN=tests/test_dcos_e2e/test_node_upgrade.py
 before_install:
 - sudo modprobe aufs
+- sudo modprobe ip6_tables
 - echo $LICENSE_KEY_CONTENTS > /tmp/license-key.txt
 - travis_retry pip install --upgrade pip setuptools codecov
 - pip uninstall -y six

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,8 @@ Changelog
 Next
 ----
 
+* Changed the default version of ``dcos-vagrant-box`` to ``0.10``.
+
 2019.10.11.0
 ------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,8 @@ Next
 ----
 
 * Changed the default version of ``dcos-vagrant-box`` to ``0.10``.
+* Updated dependencies.
+* Drop support for RHEL in ``minidcos aws``.
 
 2019.10.11.0
 ------------

--- a/admin/update_vendored_packages.py
+++ b/admin/update_vendored_packages.py
@@ -46,7 +46,7 @@ def _get_requirements() -> List[_Requirement]:
         package_name='dcos_launch',
         install_directories=['dcos_launch'],
         https_address='https://github.com/dcos/dcos-launch',
-        git_reference='693f2a81403b38b2dd77740fc350345ddab9dfcc',
+        git_reference='5df9c68a5a5f41a5bf201b961eb54140ac324635',
     )
 
     test_utils = _Requirement(
@@ -54,7 +54,7 @@ def _get_requirements() -> List[_Requirement]:
         package_name='dcos_test_utils',
         install_directories=['dcos_test_utils', 'pytest_dcos'],
         https_address='https://github.com/dcos/dcos-test-utils',
-        git_reference='9a9cafdd509bc9b8c76ab5e9f59849e7f3ace765',
+        git_reference='0957dc87e05d8b14c42e188de6a9e926839716c6',
     )
 
     dcos_launch_cli = _Requirement(
@@ -62,7 +62,7 @@ def _get_requirements() -> List[_Requirement]:
         package_name='dcos_launch',
         install_directories=['dcos_launch'],
         https_address='https://github.com/dcos/dcos-launch',
-        git_reference='693f2a81403b38b2dd77740fc350345ddab9dfcc',
+        git_reference='5df9c68a5a5f41a5bf201b961eb54140ac324635',
     )
 
     test_utils_cli = _Requirement(
@@ -70,7 +70,7 @@ def _get_requirements() -> List[_Requirement]:
         package_name='dcos_test_utils',
         install_directories=['dcos_test_utils', 'pytest_dcos'],
         https_address='https://github.com/dcos/dcos-test-utils',
-        git_reference='9a9cafdd509bc9b8c76ab5e9f59849e7f3ace765',
+        git_reference='0957dc87e05d8b14c42e188de6a9e926839716c6',
     )
 
     vertigo_e2e = _Requirement(
@@ -94,7 +94,7 @@ def _get_requirements() -> List[_Requirement]:
         package_name='dcos_installer_tools',
         install_directories=['dcos_installer_tools'],
         https_address='https://github.com/adamtheturtle/dcos-installer-tools',
-        git_reference='eed084208813c9bf0cf4ff753da85fe11909a7bb',
+        git_reference='8550cf77f0f8e9878ad4d6ec9980f675b656d966',
     )
 
     requirements = [

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,7 +9,7 @@ flake8==3.7.7
 homebrew-pypi-poet==0.10.0
 isort==4.3.21
 mypy==0.711
-pip_check_reqs==2.0.3
+pip-check-reqs-pip-gte-20==2.0.3.4
 py==1.8.0
 pydocstyle==3.0.0
 pyenchant==2.0.0

--- a/packaging-requirements.txt
+++ b/packaging-requirements.txt
@@ -1,1 +1,1 @@
-PyInstaller==3.5
+PyInstaller==3.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,4 +25,4 @@ setuptools>=41.0.1
 timeout-decorator==0.4.1
 tqdm==4.32.2
 urllib3==1.25.3
-halo==0.0.26
+halo==0.0.29

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,8 @@ semver==2.8.1
 # We use >= rather than == because Homebrew PyPI poet
 # https://github.com/tdsmith/homebrew-pypi-poet/blob/master/poet/poet.py
 # does not pin setuptools.
-setuptools>=41.0.1
+# Use <45 for https://github.com/pypa/setuptools/issues/1963
+setuptools>=41.0.1,<45
 timeout-decorator==0.4.1
 tqdm==4.32.2
 urllib3==1.25.3

--- a/src/dcos_e2e/_vendor/dcos_launch/config.py
+++ b/src/dcos_e2e/_vendor/dcos_launch/config.py
@@ -449,7 +449,7 @@ AWS_ONPREM_SCHEMA = {
         'type': 'string',
         'required': False,
         # bootstrap node requires docker to be installed
-        'default': 'cent-os-7.4-with-docker-selinux-disabled',
+        'default': 'cent-os-8.0-with-docker-selinux-permissive',
         'allowed': list(aws.OS_AMIS.keys())},
     'instance_ami': {
         'type': 'string',

--- a/src/dcos_e2e/_vendor/dcos_launch/gcp.py
+++ b/src/dcos_e2e/_vendor/dcos_launch/gcp.py
@@ -12,7 +12,7 @@ from googleapiclient.errors import HttpError
 log = logging.getLogger(__name__)
 
 
-def get_credentials(env) -> tuple:
+def get_credentials(env=None) -> tuple:
     path = None
     if env is None:
         env = os.environ.copy()

--- a/src/dcos_e2e/_vendor/dcos_launch/platforms/gcp.py
+++ b/src/dcos_e2e/_vendor/dcos_launch/platforms/gcp.py
@@ -251,7 +251,7 @@ class GcpWrapper:
                 zone = None
                 for r in deployment.get_resources()['resources']:
                     if r['type'] == 'compute.v1.instanceGroupManager':
-                        zone = r.get('properties', dict).get('zone')
+                        zone = r.get('properties', {}).get('zone')
                 if zone is None:
                     yield deployment
                 else:

--- a/src/dcos_e2e/_vendor/dcos_launch/platforms/onprem.py
+++ b/src/dcos_e2e/_vendor/dcos_launch/platforms/onprem.py
@@ -169,7 +169,7 @@ def do_genconf(
 def curl(download_url: str, out_path: str) -> list:
     """ returns a robust curl command in list form
     """
-    return ['curl', '-fLsSv', '--retry', '20', '-Y', '100000', '-y', '60',
+    return ['curl', '-fLsSv', '--retry', '20', '-Y', '100000', '-y', '90',
             '--create-dirs', '-o', out_path, download_url]
 
 

--- a/src/dcos_e2e/_vendor/dcos_launch/templates/vpc-cluster-template.json
+++ b/src/dcos_e2e/_vendor/dcos_launch/templates/vpc-cluster-template.json
@@ -258,7 +258,26 @@
                 "ec2:CopySnapshot",
                 "ec2:DeleteSnapshot",
                 "ec2:DescribeSnapshots",
-                "ec2:DescribeSnapshotAttribute"
+                "ec2:DescribeSnapshotAttribute",
+                "elasticloadbalancing:DescribeLoadBalancers",
+                "elasticloadbalancing:CreateLoadBalancer",
+                "elasticloadbalancing:DeleteLoadBalancer",
+                "elasticloadbalancing:DescribeListeners",
+                "elasticloadbalancing:CreateListener",
+                "elasticloadbalancing:DeleteListener",
+                "elasticloadbalancing:ModifyListener",
+                "elasticloadbalancing:CreateTargetGroup",
+                "elasticloadbalancing:DeleteTargetGroup",
+                "elasticloadbalancing:DescribeTargetGroups",
+                "elasticloadbalancing:ModifyTargetGroup",
+                "elasticloadbalancing:RegisterTargets",
+                "elasticloadbalancing:DeregisterTargets",
+                "elasticloadbalancing:DescribeTargetHealth",
+                "elasticloadbalancing:DescribeLoadBalancerAttributes",
+                "elasticloadbalancing:ModifyLoadBalancerAttributes",
+                "elasticloadbalancing:DescribeTags",
+                "elasticloadbalancing:AddTags",
+                "elasticloadbalancing:RemoveTags"
               ],
               "Effect": "Allow"
             }

--- a/src/dcos_e2e/_vendor/dcos_launch/templates/vpc-ebs-only-cluster-template.json
+++ b/src/dcos_e2e/_vendor/dcos_launch/templates/vpc-ebs-only-cluster-template.json
@@ -256,7 +256,26 @@
                 "ec2:CopySnapshot",
                 "ec2:DeleteSnapshot",
                 "ec2:DescribeSnapshots",
-                "ec2:DescribeSnapshotAttribute"
+                "ec2:DescribeSnapshotAttribute",
+                "elasticloadbalancing:DescribeLoadBalancers",
+                "elasticloadbalancing:CreateLoadBalancer",
+                "elasticloadbalancing:DeleteLoadBalancer",
+                "elasticloadbalancing:DescribeListeners",
+                "elasticloadbalancing:CreateListener",
+                "elasticloadbalancing:DeleteListener",
+                "elasticloadbalancing:ModifyListener",
+                "elasticloadbalancing:CreateTargetGroup",
+                "elasticloadbalancing:DeleteTargetGroup",
+                "elasticloadbalancing:DescribeTargetGroups",
+                "elasticloadbalancing:ModifyTargetGroup",
+                "elasticloadbalancing:RegisterTargets",
+                "elasticloadbalancing:DeregisterTargets",
+                "elasticloadbalancing:DescribeTargetHealth",
+                "elasticloadbalancing:DescribeLoadBalancerAttributes",
+                "elasticloadbalancing:ModifyLoadBalancerAttributes",
+                "elasticloadbalancing:DescribeTags",
+                "elasticloadbalancing:AddTags",
+                "elasticloadbalancing:RemoveTags"
               ],
               "Effect": "Allow"
             }

--- a/src/dcos_e2e/_vendor/dcos_test_utils/etcd.py
+++ b/src/dcos_e2e/_vendor/dcos_test_utils/etcd.py
@@ -1,0 +1,46 @@
+import os
+import subprocess
+
+from typing import List
+
+ETCDCTL_PATH = "/opt/mesosphere/bin/etcdctl"
+ETCD_ENDPOINTS = "127.0.0.1:2379"
+
+CA_CERT = "/run/dcos/pki/CA/ca-bundle.crt"
+
+
+def is_enterprise():
+    return os.getenv('DCOS_ENTERPRISE', 'false').lower() == 'true'
+
+
+class EtcdCtl():
+    """ wraps etcdctl around related configurations
+    """
+
+    def __init__(self, cert_type="root") -> None:
+        self._base_args = self._get_base_args(cert_type)
+
+    def _get_base_args(self, cert_type) -> List[str]:
+        args = ["sudo", ETCDCTL_PATH]
+        if is_enterprise():
+            args += ["--endpoints=https://{}".format(ETCD_ENDPOINTS)]
+            args += [
+                "--cert=/run/dcos/pki/tls/certs/etcd-client-{}.crt".format(cert_type),
+                "--key=/run/dcos/pki/tls/private/etcd-client-{}.key".format(cert_type),
+                "--cacert={}".format(CA_CERT),
+            ]
+        else:
+            args += ["--endpoints=http://{}".format(ETCD_ENDPOINTS)]
+
+        return args
+
+    def run(self, cmd: List[str], check: bool = True,
+            env: dict = {}) -> subprocess.CompletedProcess:
+        process = subprocess.run(
+            self._base_args.copy() + cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=env,
+            check=check)
+
+        return process

--- a/src/dcos_e2e/_vendor/dcos_test_utils/marathon.py
+++ b/src/dcos_e2e/_vendor/dcos_test_utils/marathon.py
@@ -142,7 +142,7 @@ class Marathon(RetryCommonHttpErrorsMixin, ApiClientSession):
             return self.check_app_instances(app_id, app_instances, check_health, ignore_failed_tasks)
         wait()
 
-    def deploy_app(self, app_definition, check_health=True, ignore_failed_tasks=False, timeout=1200):
+    def deploy_app(self, app_definition, check_health=True, ignore_failed_tasks=False, timeout=180):
         """Deploy an app to marathon
 
         This function deploys an an application and then waits for marathon to
@@ -176,7 +176,7 @@ class Marathon(RetryCommonHttpErrorsMixin, ApiClientSession):
             raise Exception("Application deployment failed - operation was not "
                             "completed in {} seconds.".format(timeout))
 
-    def deploy_pod(self, pod_definition, timeout=1200):
+    def deploy_pod(self, pod_definition, timeout=180):
         """Deploy a pod to marathon
 
         This function deploys an a pod and then waits for marathon to
@@ -284,7 +284,7 @@ class Marathon(RetryCommonHttpErrorsMixin, ApiClientSession):
                             "completed in {} seconds.".format(timeout))
 
     @contextlib.contextmanager
-    def deploy_and_cleanup(self, app_definition, timeout=1200, check_health=True, ignore_failed_tasks=True):
+    def deploy_and_cleanup(self, app_definition, timeout=180, check_health=True, ignore_failed_tasks=True):
         """ This context manager works just like :func:`Marathon.deploy_app` but will always destroy
         the app once the context is left
         """
@@ -295,7 +295,7 @@ class Marathon(RetryCommonHttpErrorsMixin, ApiClientSession):
             self.destroy_app(app_definition['id'], timeout)
 
     @contextlib.contextmanager
-    def deploy_pod_and_cleanup(self, pod_definition, timeout=1200):
+    def deploy_pod_and_cleanup(self, pod_definition, timeout=180):
         """ This context manager works just like :func:`Marathon.deploy_pod` but will always destroy
         the app once the context is left
         """

--- a/src/dcos_e2e/_vendor/dcos_test_utils/tls.py
+++ b/src/dcos_e2e/_vendor/dcos_test_utils/tls.py
@@ -1,0 +1,453 @@
+import datetime
+import uuid
+
+import cryptography.hazmat.backends
+from collections import OrderedDict
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import dsa, ec, rsa
+from cryptography.x509.oid import NameOID
+
+cryptography_default_backend = cryptography.hazmat.backends.default_backend()
+
+
+class CertValidationError(Exception):
+    pass
+
+
+def load_pem_x509_cert(cert_pem, allow_ec_cert=True):
+    """
+    Load X.509 certificate from the provided PEM/text representation.
+
+    - Expect a single X.509 certificate in the "OpenSSL PEM format"
+      (see https://tools.ietf.org/html/rfc7468#section-5 for format
+      specification).
+
+    - Expect that the public key of the certificate is of type RSA or EC
+      (if enabled via allow_ec_cert).
+
+    Note that if the certificate text representations contains more than one
+    certificate definition, x509.load_pem_x509_certificate would silently read
+    only the first one.
+
+
+    Args:
+        cert_pem (str): the PEM text representation of the data to verify.
+        allow_ec_cert (bool): True if EC public key is supported.
+
+    Returns:
+        `cert`, an object of type `cryptography.x509.Certificate`.
+
+    Raises:
+        CertValidationError
+    """
+
+    if cert_pem.count('BEGIN CERTIFICATE') > 1:
+        raise CertValidationError(
+            'Certificate data contains more than one certificate definition.')
+
+    try:
+        cert = x509.load_pem_x509_certificate(
+            data=cert_pem.encode('utf-8'),
+            backend=cryptography_default_backend
+            )
+    except ValueError as e:
+        raise CertValidationError('Invalid certificate: %s' % e)
+
+    public_key = cert.public_key()
+
+    supported_keys = OrderedDict([(rsa.RSAPublicKey, 'RSA')])
+    if allow_ec_cert:
+        supported_keys[ec.EllipticCurvePublicKey] = 'EC'
+
+    if not isinstance(public_key, tuple(supported_keys.keys())):
+        names = list(supported_keys.values())
+        if len(names) > 1:
+            names_str = ', '.join(names[:-1]) + ' or ' + names[-1]
+        else:
+            names_str = names[0]
+
+        raise CertValidationError(
+            'Unexpected public key type (not {})'.format(names_str))
+
+    return cert
+
+
+def cert_key_usage(**kwargs):
+    """
+    Helper to create x509.KeyUsage object. Function provide defaults (False)
+    for unspecified KeyUsage arguments.
+
+    Args:
+        x509.KeyUsage keys. If not provided False is used for each arg.
+
+    Return:
+        x509.KeyUsage
+    """
+    required = [
+        'digital_signature',
+        'content_commitment',
+        'key_encipherment',
+        'data_encipherment',
+        'key_agreement',
+        'key_cert_sign',
+        'crl_sign',
+        'encipher_only',
+        'decipher_only',
+    ]
+    for name in required:
+        kwargs.setdefault(name, False)
+
+    return x509.KeyUsage(**kwargs)
+
+
+def cert_extended_key_usage(**kwargs):
+    """
+    Helper to create x509.ExtendedKeyUsage object.
+
+    Args:
+        x509.ExtendedKeyUsage keys. If not provided False is used for each arg.
+
+    Return:
+        x509.ExtendedKeyUsage
+    """
+    usages = {
+        'server_auth': x509.oid.ExtendedKeyUsageOID.SERVER_AUTH,
+        'client_auth': x509.oid.ExtendedKeyUsageOID.CLIENT_AUTH,
+        'code_signing': x509.oid.ExtendedKeyUsageOID.CODE_SIGNING,
+        # ... and others, which we do not need. Check e.g.
+        # https://cryptography.io/en/latest/_modules/cryptography/x509/oid/#ExtendedKeyUsageOID
+        # for details.
+    }
+    res = []
+    for k, v in kwargs.items():
+        assert k in usages, "unknown exteneded key usage specified"
+        if v:
+            res.append(usages[k])
+
+    return x509.ExtendedKeyUsage(res)
+
+
+def cert_name(common_name):
+    """
+    Create x509.Name
+    """
+    return x509.Name([
+        x509.NameAttribute(NameOID.COUNTRY_NAME, "US"),
+        x509.NameAttribute(NameOID.STATE_OR_PROVINCE_NAME, "CA"),
+        x509.NameAttribute(NameOID.LOCALITY_NAME, "San Francisco"),
+        x509.NameAttribute(NameOID.ORGANIZATION_NAME, "D2iQ, Inc."),
+        x509.NameAttribute(NameOID.COMMON_NAME, common_name),
+        ])
+
+
+def ca_cert_builder(
+        public_key,
+        common_name="Root CA",
+        issuer=None,
+        basic_constraints=x509.BasicConstraints(
+            ca=True, path_length=None),
+        key_usage=cert_key_usage(
+            key_cert_sign=True),
+        subject_alternative_names=None,
+        not_valid_before=None,
+        not_valid_after=None,
+        valid_days=3650,
+        ):
+    return cert_builder(
+        public_key=public_key,
+        common_name=common_name,
+        issuer=issuer,
+        basic_constraints=basic_constraints,
+        key_usage=key_usage,
+        subject_alternative_names=subject_alternative_names,
+        not_valid_before=not_valid_before,
+        not_valid_after=not_valid_after,
+        valid_days=valid_days,
+    )
+
+
+def external_cert_builder(
+        public_key,
+        common_name="Web Server Cert",
+        issuer=None,
+        basic_constraints=x509.BasicConstraints(
+            ca=False, path_length=None),
+        key_usage=cert_key_usage(
+            key_cert_sign=False, digital_signature=True, key_encipherment=True),
+        extended_key_usage=cert_extended_key_usage(server_auth=True),
+        subject_alternative_names=[
+            x509.DNSName('maryna.example.com'),
+        ],
+        not_valid_before=None,
+        not_valid_after=None,
+        valid_days=3650,
+        ):
+    return cert_builder(
+        public_key=public_key,
+        common_name=common_name,
+        issuer=issuer,
+        basic_constraints=basic_constraints,
+        key_usage=key_usage,
+        extended_key_usage=extended_key_usage,
+        subject_alternative_names=subject_alternative_names,
+        not_valid_before=not_valid_before,
+        not_valid_after=not_valid_after,
+        valid_days=valid_days,
+    )
+
+
+def cert_builder(
+        public_key,
+        common_name="Root CA",
+        issuer=None,
+        basic_constraints=x509.BasicConstraints(ca=True, path_length=None),
+        key_usage=None,
+        extended_key_usage=None,
+        subject_alternative_names=None,
+        not_valid_before=None,
+        not_valid_after=None,
+        valid_days=3650,
+        ):
+    """
+    Create cert builder with some sensible defaults.
+
+    Args:
+        public_key (str): public key of the certificate
+        common_name (str): Certificate subject common name
+        issuer (x509.Name): Issuer name, if not provided subject is used
+        basic_constraints (x509.BasicConstraints): Custom basic constraints
+            extension value
+        key_usage (x509.KeyUsage): Custom key constraints extension value
+        extended_key_usage (x509.ExtendedKeyUsage): The list of extended key
+            usage attributes to apply
+        subject_alternative_names (List[x509.IPAddress or x509.DNSName]): list
+            of Subject Alternative Names to assign to the certificate
+        not_valid_before (datetime): From which time is a certificate valid
+        not_valid_after (datetime): After which time is certificate invalid
+        valid_days (int): Number of days that cert is valid
+
+    Returns:
+        x509.CertificateBuilder
+    """
+    if not_valid_before is None:
+        not_valid_before = datetime.datetime.utcnow()
+
+    if not_valid_after is None:
+        not_valid_after = not_valid_before + datetime.timedelta(days=valid_days)
+
+    subject = cert_name(common_name)
+    if issuer is None:
+        issuer = subject
+
+    builder = x509.CertificateBuilder().subject_name(
+        subject
+    ).issuer_name(
+        issuer
+    ).public_key(
+        public_key
+    ).not_valid_before(
+        not_valid_before
+    ).not_valid_after(
+        not_valid_after
+    ).serial_number(
+        int(uuid.uuid4())
+    )
+
+    if basic_constraints:
+        builder = builder.add_extension(basic_constraints, critical=True)
+
+    if key_usage is not None:
+        builder = builder.add_extension(key_usage, critical=True)
+
+    if extended_key_usage is not None:
+        builder = builder.add_extension(extended_key_usage, critical=True)
+
+    if subject_alternative_names is not None:
+        builder = builder.add_extension(
+            x509.SubjectAlternativeName(subject_alternative_names),
+            critical=True
+        )
+
+    return builder
+
+
+def serialize_cert_to_pem(cert):
+    """
+    Serialize certificate to PEM format.
+
+    Args:
+        cert (x509.Certificate): Certificate to be serialized.
+
+    Return:
+        PEM text representing serialized certificate.
+    """
+    return cert.public_bytes(encoding=serialization.Encoding.PEM).decode('utf-8')
+
+
+def serialize_cert_chain_to_pem(chain):
+    """
+    Serialize chain of certificates to PEM format string.
+
+    Args:
+        chain (List[x509.Certificate]): Chain of certificates to be serialized.
+
+    Return:
+        PEM text representing serialized certificate.
+    """
+    return ''.join([serialize_cert_to_pem(cert) for cert in chain])
+
+
+def common_names(cert):
+    return [x.value for x in cert.subject.get_attributes_for_oid(NameOID.COMMON_NAME)]
+
+
+def generate_root_ca_and_intermediate_ca(
+        number=1,
+        ):
+    """
+    Helper to create root CA cert and intermediate certs.
+
+    Args:
+        number (int): Number of intermediate certs.
+
+    Returns:
+        Certificate chain with each CA certificate followed by its issuer,
+        ending with the self-signed root certificate
+
+        List[(x509.Certificate, rsa.RSAPrivateKey)]
+    """
+    chain = []
+
+    root_ca_private_key = generate_rsa_private_key()
+    root_ca = sign_cert_builder(
+        ca_cert_builder(root_ca_private_key.public_key()),
+        root_ca_private_key
+        )
+    chain.append((root_ca, root_ca_private_key))
+
+    parent, parent_private_key = root_ca, root_ca_private_key
+    for i in range(0, number):
+        intermediate_ca_private_key = generate_rsa_private_key()
+        intermediate_ca = sign_cert_builder(
+            ca_cert_builder(
+                intermediate_ca_private_key.public_key(),
+                common_name="Intermediate CA {}".format(i),
+                issuer=parent.subject,
+                ),
+            parent_private_key
+        )
+        chain.append((intermediate_ca, intermediate_ca_private_key))
+        parent, parent_private_key = intermediate_ca, intermediate_ca_private_key
+
+    return list(reversed(chain))
+
+
+def generate_rsa_private_key(key_size=2048, public_exponent=65537):
+    """
+    Generate RSA private key.
+
+    Args:
+        key_size (int): RSA key size
+        public_exponent (int): Key public exponent
+
+    Return:
+        rsa.RSAPrivateKey
+    """
+    return rsa.generate_private_key(
+        public_exponent=public_exponent,
+        key_size=key_size,
+        backend=cryptography_default_backend
+        )
+
+
+def generate_ec_private_key(curve=None):
+    """
+    Generate EC private key.
+
+    Args:
+        curve (ec.EllipticCurve): EC if not provided SECP384R1 used.
+
+    Return:
+        ec.EllipticCurvePrivateKey
+    """
+    curve = ec.SECP384R1() if curve is None else curve
+    return ec.generate_private_key(
+        curve=curve,
+        backend=cryptography_default_backend
+        )
+
+
+def generate_dsa_private_key(key_size=1024):
+    """
+    Generate DSA private key.
+
+    Args:
+        key_size (int): Key size of DSA key.
+
+    Return:
+        ec.DSAPrivateKey
+    """
+    return dsa.generate_private_key(
+        key_size=key_size,
+        backend=cryptography_default_backend
+        )
+
+
+def sign_cert_builder(cert_builder, private_key, alg=None):
+    """
+    Create certificate from CertificateBuilder and sign with provided key and
+    algorithm.
+
+    Args:
+        cert_builder (x509.CertificateBuilder): Certificate configuration that
+            should be signed.
+
+    Return:
+        x509.Certificate
+    """
+    alg = alg if alg else hashes.SHA256()
+    return cert_builder.sign(
+        private_key=private_key,
+        algorithm=alg,
+        backend=cryptography_default_backend
+        )
+
+
+def serialize_key_to_pem(key):
+    """
+    Serialize private key to OpenSSL format with PEM encoding.
+
+    Args:
+        key (rsa.RSAPrivateKey, ec.EllipticCurvePrivateKey): Key to serialize
+
+    Returns:
+        PEM text representing serialized key.
+    """
+    return key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.NoEncryption()
+        ).decode('utf-8')
+
+
+def generate_valid_root_ca_cert_pem(private_key):
+    """
+    Helper to create and serialize root CA cert.
+
+    Args:
+        private_key (rsa.RSAPrivateKey, ec.EllipticCurvePrivateKey): Key that
+            should be used for signing the certificate.
+
+    Return:
+        PEM text representing serialized certificate.
+    """
+    return serialize_cert_to_pem(
+        sign_cert_builder(
+            ca_cert_builder(
+                private_key.public_key(),
+            ),
+            private_key
+            )
+        )

--- a/src/dcos_e2e/backends/_vagrant/__init__.py
+++ b/src/dcos_e2e/backends/_vagrant/__init__.py
@@ -25,7 +25,7 @@ class Vagrant(ClusterBackend):
         virtualbox_description: str = '',
         workspace_dir: Optional[Path] = None,
         vm_memory_mb: int = 2048,
-        vagrant_box_version: str = '~> 0.9.2',
+        vagrant_box_version: str = '~> 0.10',
         vagrant_box_url: str = (
             'https://downloads.dcos.io/dcos-vagrant/metadata.json'
         ),

--- a/src/dcos_e2e_cli/_vendor/dcos_installer_tools/_version.py
+++ b/src/dcos_e2e_cli/_vendor/dcos_installer_tools/_version.py
@@ -8,11 +8,11 @@ import json
 
 version_json = '''
 {
- "date": "2018-11-06T01:18:55+0000",
+ "date": "2019-05-19T14:44:26+0200",
  "dirty": false,
  "error": null,
- "full-revisionid": "eed084208813c9bf0cf4ff753da85fe11909a7bb",
- "version": "0+untagged.61.geed0842"
+ "full-revisionid": "8550cf77f0f8e9878ad4d6ec9980f675b656d966",
+ "version": "0+untagged.71.g8550cf7"
 }
 '''  # END VERSION_JSON
 

--- a/src/dcos_e2e_cli/_vendor/dcos_launch/config.py
+++ b/src/dcos_e2e_cli/_vendor/dcos_launch/config.py
@@ -449,7 +449,7 @@ AWS_ONPREM_SCHEMA = {
         'type': 'string',
         'required': False,
         # bootstrap node requires docker to be installed
-        'default': 'cent-os-7.4-with-docker-selinux-disabled',
+        'default': 'cent-os-8.0-with-docker-selinux-permissive',
         'allowed': list(aws.OS_AMIS.keys())},
     'instance_ami': {
         'type': 'string',

--- a/src/dcos_e2e_cli/_vendor/dcos_launch/gcp.py
+++ b/src/dcos_e2e_cli/_vendor/dcos_launch/gcp.py
@@ -12,7 +12,7 @@ from googleapiclient.errors import HttpError
 log = logging.getLogger(__name__)
 
 
-def get_credentials(env) -> tuple:
+def get_credentials(env=None) -> tuple:
     path = None
     if env is None:
         env = os.environ.copy()

--- a/src/dcos_e2e_cli/_vendor/dcos_launch/platforms/gcp.py
+++ b/src/dcos_e2e_cli/_vendor/dcos_launch/platforms/gcp.py
@@ -251,7 +251,7 @@ class GcpWrapper:
                 zone = None
                 for r in deployment.get_resources()['resources']:
                     if r['type'] == 'compute.v1.instanceGroupManager':
-                        zone = r.get('properties', dict).get('zone')
+                        zone = r.get('properties', {}).get('zone')
                 if zone is None:
                     yield deployment
                 else:

--- a/src/dcos_e2e_cli/_vendor/dcos_launch/platforms/onprem.py
+++ b/src/dcos_e2e_cli/_vendor/dcos_launch/platforms/onprem.py
@@ -169,7 +169,7 @@ def do_genconf(
 def curl(download_url: str, out_path: str) -> list:
     """ returns a robust curl command in list form
     """
-    return ['curl', '-fLsSv', '--retry', '20', '-Y', '100000', '-y', '60',
+    return ['curl', '-fLsSv', '--retry', '20', '-Y', '100000', '-y', '90',
             '--create-dirs', '-o', out_path, download_url]
 
 

--- a/src/dcos_e2e_cli/_vendor/dcos_launch/templates/vpc-cluster-template.json
+++ b/src/dcos_e2e_cli/_vendor/dcos_launch/templates/vpc-cluster-template.json
@@ -258,7 +258,26 @@
                 "ec2:CopySnapshot",
                 "ec2:DeleteSnapshot",
                 "ec2:DescribeSnapshots",
-                "ec2:DescribeSnapshotAttribute"
+                "ec2:DescribeSnapshotAttribute",
+                "elasticloadbalancing:DescribeLoadBalancers",
+                "elasticloadbalancing:CreateLoadBalancer",
+                "elasticloadbalancing:DeleteLoadBalancer",
+                "elasticloadbalancing:DescribeListeners",
+                "elasticloadbalancing:CreateListener",
+                "elasticloadbalancing:DeleteListener",
+                "elasticloadbalancing:ModifyListener",
+                "elasticloadbalancing:CreateTargetGroup",
+                "elasticloadbalancing:DeleteTargetGroup",
+                "elasticloadbalancing:DescribeTargetGroups",
+                "elasticloadbalancing:ModifyTargetGroup",
+                "elasticloadbalancing:RegisterTargets",
+                "elasticloadbalancing:DeregisterTargets",
+                "elasticloadbalancing:DescribeTargetHealth",
+                "elasticloadbalancing:DescribeLoadBalancerAttributes",
+                "elasticloadbalancing:ModifyLoadBalancerAttributes",
+                "elasticloadbalancing:DescribeTags",
+                "elasticloadbalancing:AddTags",
+                "elasticloadbalancing:RemoveTags"
               ],
               "Effect": "Allow"
             }

--- a/src/dcos_e2e_cli/_vendor/dcos_launch/templates/vpc-ebs-only-cluster-template.json
+++ b/src/dcos_e2e_cli/_vendor/dcos_launch/templates/vpc-ebs-only-cluster-template.json
@@ -256,7 +256,26 @@
                 "ec2:CopySnapshot",
                 "ec2:DeleteSnapshot",
                 "ec2:DescribeSnapshots",
-                "ec2:DescribeSnapshotAttribute"
+                "ec2:DescribeSnapshotAttribute",
+                "elasticloadbalancing:DescribeLoadBalancers",
+                "elasticloadbalancing:CreateLoadBalancer",
+                "elasticloadbalancing:DeleteLoadBalancer",
+                "elasticloadbalancing:DescribeListeners",
+                "elasticloadbalancing:CreateListener",
+                "elasticloadbalancing:DeleteListener",
+                "elasticloadbalancing:ModifyListener",
+                "elasticloadbalancing:CreateTargetGroup",
+                "elasticloadbalancing:DeleteTargetGroup",
+                "elasticloadbalancing:DescribeTargetGroups",
+                "elasticloadbalancing:ModifyTargetGroup",
+                "elasticloadbalancing:RegisterTargets",
+                "elasticloadbalancing:DeregisterTargets",
+                "elasticloadbalancing:DescribeTargetHealth",
+                "elasticloadbalancing:DescribeLoadBalancerAttributes",
+                "elasticloadbalancing:ModifyLoadBalancerAttributes",
+                "elasticloadbalancing:DescribeTags",
+                "elasticloadbalancing:AddTags",
+                "elasticloadbalancing:RemoveTags"
               ],
               "Effect": "Allow"
             }

--- a/src/dcos_e2e_cli/_vendor/dcos_test_utils/etcd.py
+++ b/src/dcos_e2e_cli/_vendor/dcos_test_utils/etcd.py
@@ -1,0 +1,46 @@
+import os
+import subprocess
+
+from typing import List
+
+ETCDCTL_PATH = "/opt/mesosphere/bin/etcdctl"
+ETCD_ENDPOINTS = "127.0.0.1:2379"
+
+CA_CERT = "/run/dcos/pki/CA/ca-bundle.crt"
+
+
+def is_enterprise():
+    return os.getenv('DCOS_ENTERPRISE', 'false').lower() == 'true'
+
+
+class EtcdCtl():
+    """ wraps etcdctl around related configurations
+    """
+
+    def __init__(self, cert_type="root") -> None:
+        self._base_args = self._get_base_args(cert_type)
+
+    def _get_base_args(self, cert_type) -> List[str]:
+        args = ["sudo", ETCDCTL_PATH]
+        if is_enterprise():
+            args += ["--endpoints=https://{}".format(ETCD_ENDPOINTS)]
+            args += [
+                "--cert=/run/dcos/pki/tls/certs/etcd-client-{}.crt".format(cert_type),
+                "--key=/run/dcos/pki/tls/private/etcd-client-{}.key".format(cert_type),
+                "--cacert={}".format(CA_CERT),
+            ]
+        else:
+            args += ["--endpoints=http://{}".format(ETCD_ENDPOINTS)]
+
+        return args
+
+    def run(self, cmd: List[str], check: bool = True,
+            env: dict = {}) -> subprocess.CompletedProcess:
+        process = subprocess.run(
+            self._base_args.copy() + cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=env,
+            check=check)
+
+        return process

--- a/src/dcos_e2e_cli/_vendor/dcos_test_utils/marathon.py
+++ b/src/dcos_e2e_cli/_vendor/dcos_test_utils/marathon.py
@@ -142,7 +142,7 @@ class Marathon(RetryCommonHttpErrorsMixin, ApiClientSession):
             return self.check_app_instances(app_id, app_instances, check_health, ignore_failed_tasks)
         wait()
 
-    def deploy_app(self, app_definition, check_health=True, ignore_failed_tasks=False, timeout=1200):
+    def deploy_app(self, app_definition, check_health=True, ignore_failed_tasks=False, timeout=180):
         """Deploy an app to marathon
 
         This function deploys an an application and then waits for marathon to
@@ -176,7 +176,7 @@ class Marathon(RetryCommonHttpErrorsMixin, ApiClientSession):
             raise Exception("Application deployment failed - operation was not "
                             "completed in {} seconds.".format(timeout))
 
-    def deploy_pod(self, pod_definition, timeout=1200):
+    def deploy_pod(self, pod_definition, timeout=180):
         """Deploy a pod to marathon
 
         This function deploys an a pod and then waits for marathon to
@@ -284,7 +284,7 @@ class Marathon(RetryCommonHttpErrorsMixin, ApiClientSession):
                             "completed in {} seconds.".format(timeout))
 
     @contextlib.contextmanager
-    def deploy_and_cleanup(self, app_definition, timeout=1200, check_health=True, ignore_failed_tasks=True):
+    def deploy_and_cleanup(self, app_definition, timeout=180, check_health=True, ignore_failed_tasks=True):
         """ This context manager works just like :func:`Marathon.deploy_app` but will always destroy
         the app once the context is left
         """
@@ -295,7 +295,7 @@ class Marathon(RetryCommonHttpErrorsMixin, ApiClientSession):
             self.destroy_app(app_definition['id'], timeout)
 
     @contextlib.contextmanager
-    def deploy_pod_and_cleanup(self, pod_definition, timeout=1200):
+    def deploy_pod_and_cleanup(self, pod_definition, timeout=180):
         """ This context manager works just like :func:`Marathon.deploy_pod` but will always destroy
         the app once the context is left
         """

--- a/src/dcos_e2e_cli/_vendor/dcos_test_utils/tls.py
+++ b/src/dcos_e2e_cli/_vendor/dcos_test_utils/tls.py
@@ -1,0 +1,453 @@
+import datetime
+import uuid
+
+import cryptography.hazmat.backends
+from collections import OrderedDict
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import dsa, ec, rsa
+from cryptography.x509.oid import NameOID
+
+cryptography_default_backend = cryptography.hazmat.backends.default_backend()
+
+
+class CertValidationError(Exception):
+    pass
+
+
+def load_pem_x509_cert(cert_pem, allow_ec_cert=True):
+    """
+    Load X.509 certificate from the provided PEM/text representation.
+
+    - Expect a single X.509 certificate in the "OpenSSL PEM format"
+      (see https://tools.ietf.org/html/rfc7468#section-5 for format
+      specification).
+
+    - Expect that the public key of the certificate is of type RSA or EC
+      (if enabled via allow_ec_cert).
+
+    Note that if the certificate text representations contains more than one
+    certificate definition, x509.load_pem_x509_certificate would silently read
+    only the first one.
+
+
+    Args:
+        cert_pem (str): the PEM text representation of the data to verify.
+        allow_ec_cert (bool): True if EC public key is supported.
+
+    Returns:
+        `cert`, an object of type `cryptography.x509.Certificate`.
+
+    Raises:
+        CertValidationError
+    """
+
+    if cert_pem.count('BEGIN CERTIFICATE') > 1:
+        raise CertValidationError(
+            'Certificate data contains more than one certificate definition.')
+
+    try:
+        cert = x509.load_pem_x509_certificate(
+            data=cert_pem.encode('utf-8'),
+            backend=cryptography_default_backend
+            )
+    except ValueError as e:
+        raise CertValidationError('Invalid certificate: %s' % e)
+
+    public_key = cert.public_key()
+
+    supported_keys = OrderedDict([(rsa.RSAPublicKey, 'RSA')])
+    if allow_ec_cert:
+        supported_keys[ec.EllipticCurvePublicKey] = 'EC'
+
+    if not isinstance(public_key, tuple(supported_keys.keys())):
+        names = list(supported_keys.values())
+        if len(names) > 1:
+            names_str = ', '.join(names[:-1]) + ' or ' + names[-1]
+        else:
+            names_str = names[0]
+
+        raise CertValidationError(
+            'Unexpected public key type (not {})'.format(names_str))
+
+    return cert
+
+
+def cert_key_usage(**kwargs):
+    """
+    Helper to create x509.KeyUsage object. Function provide defaults (False)
+    for unspecified KeyUsage arguments.
+
+    Args:
+        x509.KeyUsage keys. If not provided False is used for each arg.
+
+    Return:
+        x509.KeyUsage
+    """
+    required = [
+        'digital_signature',
+        'content_commitment',
+        'key_encipherment',
+        'data_encipherment',
+        'key_agreement',
+        'key_cert_sign',
+        'crl_sign',
+        'encipher_only',
+        'decipher_only',
+    ]
+    for name in required:
+        kwargs.setdefault(name, False)
+
+    return x509.KeyUsage(**kwargs)
+
+
+def cert_extended_key_usage(**kwargs):
+    """
+    Helper to create x509.ExtendedKeyUsage object.
+
+    Args:
+        x509.ExtendedKeyUsage keys. If not provided False is used for each arg.
+
+    Return:
+        x509.ExtendedKeyUsage
+    """
+    usages = {
+        'server_auth': x509.oid.ExtendedKeyUsageOID.SERVER_AUTH,
+        'client_auth': x509.oid.ExtendedKeyUsageOID.CLIENT_AUTH,
+        'code_signing': x509.oid.ExtendedKeyUsageOID.CODE_SIGNING,
+        # ... and others, which we do not need. Check e.g.
+        # https://cryptography.io/en/latest/_modules/cryptography/x509/oid/#ExtendedKeyUsageOID
+        # for details.
+    }
+    res = []
+    for k, v in kwargs.items():
+        assert k in usages, "unknown exteneded key usage specified"
+        if v:
+            res.append(usages[k])
+
+    return x509.ExtendedKeyUsage(res)
+
+
+def cert_name(common_name):
+    """
+    Create x509.Name
+    """
+    return x509.Name([
+        x509.NameAttribute(NameOID.COUNTRY_NAME, "US"),
+        x509.NameAttribute(NameOID.STATE_OR_PROVINCE_NAME, "CA"),
+        x509.NameAttribute(NameOID.LOCALITY_NAME, "San Francisco"),
+        x509.NameAttribute(NameOID.ORGANIZATION_NAME, "D2iQ, Inc."),
+        x509.NameAttribute(NameOID.COMMON_NAME, common_name),
+        ])
+
+
+def ca_cert_builder(
+        public_key,
+        common_name="Root CA",
+        issuer=None,
+        basic_constraints=x509.BasicConstraints(
+            ca=True, path_length=None),
+        key_usage=cert_key_usage(
+            key_cert_sign=True),
+        subject_alternative_names=None,
+        not_valid_before=None,
+        not_valid_after=None,
+        valid_days=3650,
+        ):
+    return cert_builder(
+        public_key=public_key,
+        common_name=common_name,
+        issuer=issuer,
+        basic_constraints=basic_constraints,
+        key_usage=key_usage,
+        subject_alternative_names=subject_alternative_names,
+        not_valid_before=not_valid_before,
+        not_valid_after=not_valid_after,
+        valid_days=valid_days,
+    )
+
+
+def external_cert_builder(
+        public_key,
+        common_name="Web Server Cert",
+        issuer=None,
+        basic_constraints=x509.BasicConstraints(
+            ca=False, path_length=None),
+        key_usage=cert_key_usage(
+            key_cert_sign=False, digital_signature=True, key_encipherment=True),
+        extended_key_usage=cert_extended_key_usage(server_auth=True),
+        subject_alternative_names=[
+            x509.DNSName('maryna.example.com'),
+        ],
+        not_valid_before=None,
+        not_valid_after=None,
+        valid_days=3650,
+        ):
+    return cert_builder(
+        public_key=public_key,
+        common_name=common_name,
+        issuer=issuer,
+        basic_constraints=basic_constraints,
+        key_usage=key_usage,
+        extended_key_usage=extended_key_usage,
+        subject_alternative_names=subject_alternative_names,
+        not_valid_before=not_valid_before,
+        not_valid_after=not_valid_after,
+        valid_days=valid_days,
+    )
+
+
+def cert_builder(
+        public_key,
+        common_name="Root CA",
+        issuer=None,
+        basic_constraints=x509.BasicConstraints(ca=True, path_length=None),
+        key_usage=None,
+        extended_key_usage=None,
+        subject_alternative_names=None,
+        not_valid_before=None,
+        not_valid_after=None,
+        valid_days=3650,
+        ):
+    """
+    Create cert builder with some sensible defaults.
+
+    Args:
+        public_key (str): public key of the certificate
+        common_name (str): Certificate subject common name
+        issuer (x509.Name): Issuer name, if not provided subject is used
+        basic_constraints (x509.BasicConstraints): Custom basic constraints
+            extension value
+        key_usage (x509.KeyUsage): Custom key constraints extension value
+        extended_key_usage (x509.ExtendedKeyUsage): The list of extended key
+            usage attributes to apply
+        subject_alternative_names (List[x509.IPAddress or x509.DNSName]): list
+            of Subject Alternative Names to assign to the certificate
+        not_valid_before (datetime): From which time is a certificate valid
+        not_valid_after (datetime): After which time is certificate invalid
+        valid_days (int): Number of days that cert is valid
+
+    Returns:
+        x509.CertificateBuilder
+    """
+    if not_valid_before is None:
+        not_valid_before = datetime.datetime.utcnow()
+
+    if not_valid_after is None:
+        not_valid_after = not_valid_before + datetime.timedelta(days=valid_days)
+
+    subject = cert_name(common_name)
+    if issuer is None:
+        issuer = subject
+
+    builder = x509.CertificateBuilder().subject_name(
+        subject
+    ).issuer_name(
+        issuer
+    ).public_key(
+        public_key
+    ).not_valid_before(
+        not_valid_before
+    ).not_valid_after(
+        not_valid_after
+    ).serial_number(
+        int(uuid.uuid4())
+    )
+
+    if basic_constraints:
+        builder = builder.add_extension(basic_constraints, critical=True)
+
+    if key_usage is not None:
+        builder = builder.add_extension(key_usage, critical=True)
+
+    if extended_key_usage is not None:
+        builder = builder.add_extension(extended_key_usage, critical=True)
+
+    if subject_alternative_names is not None:
+        builder = builder.add_extension(
+            x509.SubjectAlternativeName(subject_alternative_names),
+            critical=True
+        )
+
+    return builder
+
+
+def serialize_cert_to_pem(cert):
+    """
+    Serialize certificate to PEM format.
+
+    Args:
+        cert (x509.Certificate): Certificate to be serialized.
+
+    Return:
+        PEM text representing serialized certificate.
+    """
+    return cert.public_bytes(encoding=serialization.Encoding.PEM).decode('utf-8')
+
+
+def serialize_cert_chain_to_pem(chain):
+    """
+    Serialize chain of certificates to PEM format string.
+
+    Args:
+        chain (List[x509.Certificate]): Chain of certificates to be serialized.
+
+    Return:
+        PEM text representing serialized certificate.
+    """
+    return ''.join([serialize_cert_to_pem(cert) for cert in chain])
+
+
+def common_names(cert):
+    return [x.value for x in cert.subject.get_attributes_for_oid(NameOID.COMMON_NAME)]
+
+
+def generate_root_ca_and_intermediate_ca(
+        number=1,
+        ):
+    """
+    Helper to create root CA cert and intermediate certs.
+
+    Args:
+        number (int): Number of intermediate certs.
+
+    Returns:
+        Certificate chain with each CA certificate followed by its issuer,
+        ending with the self-signed root certificate
+
+        List[(x509.Certificate, rsa.RSAPrivateKey)]
+    """
+    chain = []
+
+    root_ca_private_key = generate_rsa_private_key()
+    root_ca = sign_cert_builder(
+        ca_cert_builder(root_ca_private_key.public_key()),
+        root_ca_private_key
+        )
+    chain.append((root_ca, root_ca_private_key))
+
+    parent, parent_private_key = root_ca, root_ca_private_key
+    for i in range(0, number):
+        intermediate_ca_private_key = generate_rsa_private_key()
+        intermediate_ca = sign_cert_builder(
+            ca_cert_builder(
+                intermediate_ca_private_key.public_key(),
+                common_name="Intermediate CA {}".format(i),
+                issuer=parent.subject,
+                ),
+            parent_private_key
+        )
+        chain.append((intermediate_ca, intermediate_ca_private_key))
+        parent, parent_private_key = intermediate_ca, intermediate_ca_private_key
+
+    return list(reversed(chain))
+
+
+def generate_rsa_private_key(key_size=2048, public_exponent=65537):
+    """
+    Generate RSA private key.
+
+    Args:
+        key_size (int): RSA key size
+        public_exponent (int): Key public exponent
+
+    Return:
+        rsa.RSAPrivateKey
+    """
+    return rsa.generate_private_key(
+        public_exponent=public_exponent,
+        key_size=key_size,
+        backend=cryptography_default_backend
+        )
+
+
+def generate_ec_private_key(curve=None):
+    """
+    Generate EC private key.
+
+    Args:
+        curve (ec.EllipticCurve): EC if not provided SECP384R1 used.
+
+    Return:
+        ec.EllipticCurvePrivateKey
+    """
+    curve = ec.SECP384R1() if curve is None else curve
+    return ec.generate_private_key(
+        curve=curve,
+        backend=cryptography_default_backend
+        )
+
+
+def generate_dsa_private_key(key_size=1024):
+    """
+    Generate DSA private key.
+
+    Args:
+        key_size (int): Key size of DSA key.
+
+    Return:
+        ec.DSAPrivateKey
+    """
+    return dsa.generate_private_key(
+        key_size=key_size,
+        backend=cryptography_default_backend
+        )
+
+
+def sign_cert_builder(cert_builder, private_key, alg=None):
+    """
+    Create certificate from CertificateBuilder and sign with provided key and
+    algorithm.
+
+    Args:
+        cert_builder (x509.CertificateBuilder): Certificate configuration that
+            should be signed.
+
+    Return:
+        x509.Certificate
+    """
+    alg = alg if alg else hashes.SHA256()
+    return cert_builder.sign(
+        private_key=private_key,
+        algorithm=alg,
+        backend=cryptography_default_backend
+        )
+
+
+def serialize_key_to_pem(key):
+    """
+    Serialize private key to OpenSSL format with PEM encoding.
+
+    Args:
+        key (rsa.RSAPrivateKey, ec.EllipticCurvePrivateKey): Key to serialize
+
+    Returns:
+        PEM text representing serialized key.
+    """
+    return key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.NoEncryption()
+        ).decode('utf-8')
+
+
+def generate_valid_root_ca_cert_pem(private_key):
+    """
+    Helper to create and serialize root CA cert.
+
+    Args:
+        private_key (rsa.RSAPrivateKey, ec.EllipticCurvePrivateKey): Key that
+            should be used for signing the certificate.
+
+    Return:
+        PEM text representing serialized certificate.
+    """
+    return serialize_cert_to_pem(
+        sign_cert_builder(
+            ca_cert_builder(
+                private_key.public_key(),
+            ),
+            private_key
+            )
+        )

--- a/src/dcos_e2e_cli/dcos_aws/commands/_common.py
+++ b/src/dcos_e2e_cli/dcos_aws/commands/_common.py
@@ -19,7 +19,6 @@ CLUSTER_ID_TAG_KEY = 'dcos_e2e.cluster_id'
 KEY_NAME_TAG_KEY = 'dcos_e2e.key_name'
 LINUX_DISTRIBUTIONS = {
     'centos-7': Distribution.CENTOS_7,
-    'rhel-7': Distribution.RHEL_7,
     'coreos': Distribution.COREOS,
 }
 NODE_TYPE_TAG_KEY = 'dcos_e2e.node_type'

--- a/tests/test_admin/test_brew.py
+++ b/tests/test_admin/test_brew.py
@@ -7,6 +7,7 @@ import subprocess
 from pathlib import Path
 
 import docker
+import pytest
 from docker.types import Mount
 from dulwich.repo import Repo
 
@@ -15,6 +16,7 @@ from admin.homebrew import get_homebrew_formula
 LOGGER = logging.getLogger(__name__)
 
 
+@pytest.mark.xfail(reason='https://jira.d2iq.com/browse/DCOS_OSS-5962')
 def test_brew(tmp_path: Path) -> None:
     """
     It is possible to create a Homebrew formula and to install this with

--- a/tests/test_cli/test_dcos_aws/help_outputs/dcos-aws-create.txt
+++ b/tests/test_cli/test_dcos_aws/help_outputs/dcos-aws-create.txt
@@ -48,7 +48,7 @@ Options:
   --aws-instance-type TEXT        The AWS instance type to use.  [default:
                                   m4.large]
   --aws-region TEXT               The AWS region to use.  [default: us-west-2]
-  --linux-distribution [centos-7|coreos|rhel-7]
+  --linux-distribution [centos-7|coreos]
                                   The Linux distribution to use on the nodes.
                                   [default: centos-7]
   --workspace-dir DIRECTORY       Creating a cluster can use approximately 2 GB

--- a/tests/test_cli/test_dcos_aws/help_outputs/dcos-aws-provision.txt
+++ b/tests/test_cli/test_dcos_aws/help_outputs/dcos-aws-provision.txt
@@ -12,7 +12,7 @@ Options:
   --aws-instance-type TEXT        The AWS instance type to use.  [default:
                                   m4.large]
   --aws-region TEXT               The AWS region to use.  [default: us-west-2]
-  --linux-distribution [centos-7|coreos|rhel-7]
+  --linux-distribution [centos-7|coreos]
                                   The Linux distribution to use on the nodes.
                                   [default: centos-7]
   --workspace-dir DIRECTORY       Creating a cluster can use approximately 2 GB

--- a/tests/test_cli/test_dcos_vagrant/help_outputs/dcos-vagrant-create.txt
+++ b/tests/test_cli/test_dcos_vagrant/help_outputs/dcos-vagrant-create.txt
@@ -85,7 +85,7 @@ Options:
   --vagrant-box-version TEXT      The version of the Vagrant box to use. See htt
                                   ps://www.vagrantup.com/docs/boxes/versioning.h
                                   tml#version-constraints for details.
-                                  [default: ~> 0.9.2]
+                                  [default: ~> 0.10]
   --wait-for-dcos                 Wait for DC/OS after creating the cluster.
                                   This is equivalent to using "minidcos vagrant
                                   wait" after this command.

--- a/tests/test_cli/test_dcos_vagrant/help_outputs/dcos-vagrant-provision.txt
+++ b/tests/test_cli/test_dcos_vagrant/help_outputs/dcos-vagrant-provision.txt
@@ -31,7 +31,7 @@ Options:
   --vagrant-box-version TEXT      The version of the Vagrant box to use. See htt
                                   ps://www.vagrantup.com/docs/boxes/versioning.h
                                   tml#version-constraints for details.
-                                  [default: ~> 0.9.2]
+                                  [default: ~> 0.10]
   --vm-memory-mb INTEGER          The amount of memory to give each VM.
                                   [default: 2048]
   -h, --help                      Show this message and exit.

--- a/tests/test_dcos_e2e/backends/aws/test_distributions.py
+++ b/tests/test_dcos_e2e/backends/aws/test_distributions.py
@@ -4,6 +4,7 @@ Test DC/OS on all supported distributions on Amazon Web Services.
 
 import uuid
 
+import pytest
 from passlib.hash import sha512_crypt
 
 from dcos_e2e.backends import AWS
@@ -165,6 +166,7 @@ class TestCentos7:
         assert node_distribution == Distribution.CENTOS_7
 
 
+@pytest.mark.xfail(reason='dcos_launch does not have working RHEL image')
 class TestRHEL7:
     """
     Tests for the Red Hat Enterprise Linux 7 distribution option.

--- a/tests/test_dcos_e2e/test_cluster.py
+++ b/tests/test_dcos_e2e/test_cluster.py
@@ -362,7 +362,7 @@ class TestClusterFromNodes:
                 *cluster.public_agents,
             }:
                 build = node.dcos_build_info()
-                assert build.version.startswith('2.1')
+                assert build.version.startswith('2.2')
                 assert build.commit
                 assert build.variant == DCOSVariant.OSS
 


### PR DESCRIPTION
dcos-vagrant-box version 0.9.2 refers to a Docker repo that no longer exists.
https://www.docker.com/blog/changes-dockerproject-org-apt-yum-repositories/

Update to version 0.10.0 with the new repo.

Fixes #1875, fixes #1877 