### PR TITLE
Update google-api-python-client and dev dependencies

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,8 @@ Changelog
 Next
 ----
 
+* Updated ``google-api-python-client`` to ``v1.7.12``.
+
 2020.05.26.0
 ------------
 

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ open-docs:
 	python -c 'import os, webbrowser; webbrowser.open("file://" + os.path.abspath("docs/cli/build/html/index.html"))'
 
 # We pull Docker images before the tests start to catch any flakiness early.
-# See https://jira.mesosphere.com/browse/DCOS_OSS-2120 for details of
+# See https://jira.d2iq.com/browse/DCOS_OSS-2120 for details of
 # flakiness.
 .PHONY: pull-images
 pull-images:

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,8 +4,8 @@ dcoscli==0.6.1
 doc8==0.8.0
 dulwich==0.19.11
 flake8-commas==2.0.0
-flake8-quotes==2.0.1
-flake8==3.7.7
+flake8-quotes==3.2.0
+flake8==3.8.3
 homebrew-pypi-poet==0.10.0
 isort==4.3.21
 mypy==0.711
@@ -23,7 +23,7 @@ sphinx==2.1.2
 sphinx-autodoc-typehints==1.6.0
 sphinx-click==2.2.0
 sphinx-paramlinks==0.3.7
-Sphinx-Substitution-Extensions==2019.6.15.0
+Sphinx-Substitution-Extensions==2020.5.23.0
 sphinxcontrib-spelling==4.3.0
 vendorize==0.2.1
 vulture==1.0

--- a/docs/cli/source/conf.py
+++ b/docs/cli/source/conf.py
@@ -102,7 +102,7 @@ spelling_word_list_filename = '../../../spelling_private_dict.txt'
 autodoc_member_order = 'bysource'
 
 extlinks = {
-    'issue': ('https://jira.mesosphere.com/browse/%s', 'issue '),
+    'issue': ('https://jira.d2iq.com/browse/%s', 'issue '),
 }
 
 rst_epilog = """

--- a/docs/library/source/conf.py
+++ b/docs/library/source/conf.py
@@ -112,7 +112,7 @@ spelling_word_list_filename = '../../../spelling_private_dict.txt'
 autodoc_member_order = 'bysource'
 
 extlinks = {
-    'issue': ('https://jira.mesosphere.com/browse/%s', 'issue '),
+    'issue': ('https://jira.d2iq.com/browse/%s', 'issue '),
 }
 
 rst_epilog = """

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ click-pathlib==2019.6.13.1
 cryptography==2.7
 docker==4.0.2
 docopt==0.6.2
-google-api-python-client==1.7.9
+google-api-python-client==1.7.12
 oauth2client==4.1.3
 paramiko==2.6.0
 passlib==1.7.1

--- a/src/dcos_e2e/_vendor/dcos_launch/platforms/onprem.py
+++ b/src/dcos_e2e/_vendor/dcos_launch/platforms/onprem.py
@@ -256,7 +256,7 @@ def do_postflight(client: ssh_client.AsyncSshClient):
     """Runs a script that will check if DC/OS is operational without needing to authenticate
 
     It waits 20mins+ for the cluster poststart checks to succeed.
-    See https://jira.mesosphere.com/browse/DCOS-41568.
+    See https://jira.d2iq.com/browse/DCOS-41568.
     """
     postflight_script = """
 function run_command_until_success() {

--- a/src/dcos_e2e/_wait_for_dcos.py
+++ b/src/dcos_e2e/_wait_for_dcos.py
@@ -261,7 +261,7 @@ def wait_for_dcos_ee(
         # suggestion.
 
         # The progress on a partial replacement can be followed here:
-        # https://jira.mesosphere.com/browse/DCOS_OSS-1313
+        # https://jira.d2iq.com/browse/DCOS_OSS-1313
 
         # In order to fully replace this method one would need to have
         # DC/OS checks for every HTTP endpoint exposed by Admin Router.

--- a/src/dcos_e2e/backends/_aws/__init__.py
+++ b/src/dcos_e2e/backends/_aws/__init__.py
@@ -110,7 +110,7 @@ class AWS(ClusterBackend):
                 Distribution.RHEL_7,
                 Distribution.COREOS,
                 # Support for Ubuntu is blocked on
-                # https://jira.mesosphere.com/browse/DCOS_OSS-3876.
+                # https://jira.d2iq.com/browse/DCOS_OSS-3876.
             ],
         )
 
@@ -208,7 +208,7 @@ class AWSCluster(ClusterManager):
             True,
             # There is a bug hit when using ``install_prereqs`` with some
             # distributions.
-            # See https://jira.mesosphere.com/browse/DCOS-40894.
+            # See https://jira.d2iq.com/browse/DCOS-40894.
             Distribution.CENTOS_7:
             False,
             Distribution.RHEL_7:
@@ -431,7 +431,7 @@ class AWSCluster(ClusterManager):
         # Deletion only works if valid AWS credentials are present. This
         # a problem if temporary credentials become invalid before
         # destroying a cluster because the generated AWS KeyPair persists.
-        # https://jira.mesosphere.com/browse/DCOS-21893
+        # https://jira.d2iq.com/browse/DCOS-21893
         self.launcher.delete()
 
         rmtree(path=str(self._path), ignore_errors=True)

--- a/src/dcos_e2e/backends/_docker/__init__.py
+++ b/src/dcos_e2e/backends/_docker/__init__.py
@@ -259,7 +259,7 @@ class Docker(ClusterBackend):
         #
         # This has a problem - some hosts do not have systemd, and therefore
         # ``/sys/fs/cgroup`` is not available, and a mount error is shown.
-        # See https://jira.mesosphere.com/browse/DCOS_OSS-4475 for details.
+        # See https://jira.d2iq.com/browse/DCOS_OSS-4475 for details.
         cgroup_mount = Mount(
             source='/sys/fs/cgroup',
             target='/sys/fs/cgroup',

--- a/src/dcos_e2e/backends/_docker/_containers.py
+++ b/src/dcos_e2e/backends/_docker/_containers.py
@@ -96,7 +96,7 @@ def start_dcos_container(
     In this container, start Docker and `sshd`.
 
     Run Mesos without `systemd` support. This is not supported by DC/OS.
-    See https://jira.mesosphere.com/browse/DCOS_OSS-1131.
+    See https://jira.d2iq.com/browse/DCOS_OSS-1131.
 
     Args:
         container_base_name: The start of the container name.
@@ -187,7 +187,7 @@ def start_dcos_container(
         '/bin/bash -c "{cmd}"'.format(cmd=' '.join(echo_key)),
         ['rm', '-f', '/run/nologin', '||', 'true'],
         ['systemctl', 'start', 'sshd'],
-        # Work around https://jira.mesosphere.com/browse/DCOS_OSS-1361.
+        # Work around https://jira.d2iq.com/browse/DCOS_OSS-1361.
         ['systemd-tmpfiles', '--create', '--prefix', '/var/log/journal'],
         ['systemd-tmpfiles', '--create', '--prefix', '/run/log/journal'],
     ]:

--- a/src/dcos_e2e/backends/_docker/resources/dockerfiles/base/centos-7/Dockerfile
+++ b/src/dcos_e2e/backends/_docker/resources/dockerfiles/base/centos-7/Dockerfile
@@ -45,7 +45,7 @@ done \
 && ln -vf /lib/systemd/system/multi-user.target /lib/systemd/system/default.target
 
 # This works around a systemd bug.
-# See https://jira.mesosphere.com/browse/DCOS_OSS-1240
+# See https://jira.d2iq.com/browse/DCOS_OSS-1240
 RUN echo '[Unit]' >> /lib/systemd/system/systemd-journald-init.service
 RUN echo 'Description=Initialize /run/log/journal ACLs' >> /lib/systemd/system/systemd-journald-init.service
 RUN echo 'After=systemd-journald.service' >> /lib/systemd/system/systemd-journald-init.service

--- a/src/dcos_e2e/backends/_docker/resources/dockerfiles/base/coreos/Dockerfile
+++ b/src/dcos_e2e/backends/_docker/resources/dockerfiles/base/coreos/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/shift/coreos:stable-1298.7.0
 
 # This works around a systemd bug.
-# See https://jira.mesosphere.com/browse/DCOS_OSS-1240
+# See https://jira.d2iq.com/browse/DCOS_OSS-1240
 RUN echo '[Unit]' >> /lib/systemd/system/systemd-journald-init.service
 RUN echo 'Description=Initialize /run/log/journal ACLs' >> /lib/systemd/system/systemd-journald-init.service
 RUN echo 'After=systemd-journald.service' >> /lib/systemd/system/systemd-journald-init.service

--- a/src/dcos_e2e/backends/_docker/resources/dockerfiles/base/ubuntu-xenial/Dockerfile
+++ b/src/dcos_e2e/backends/_docker/resources/dockerfiles/base/ubuntu-xenial/Dockerfile
@@ -55,7 +55,7 @@ RUN ln -s /usr/sbin/groupadd /usr/bin/groupadd
 RUN ln -s /bin/systemd-tmpfiles /usr/bin/systemd-tmpfiles
 
 # This works around a systemd bug.
-# See https://jira.mesosphere.com/browse/DCOS_OSS-1240
+# See https://jira.d2iq.com/browse/DCOS_OSS-1240
 RUN echo '[Unit]' >> /lib/systemd/system/systemd-journald-init.service
 RUN echo 'Description=Initialize /run/log/journal ACLs' >> /lib/systemd/system/systemd-journald-init.service
 RUN echo 'After=systemd-journald.service' >> /lib/systemd/system/systemd-journald-init.service

--- a/src/dcos_e2e/backends/_vagrant/__init__.py
+++ b/src/dcos_e2e/backends/_vagrant/__init__.py
@@ -86,7 +86,7 @@ class Vagrant(ClusterBackend):
         """
         Return a base configuration for installing DC/OS OSS.
         """
-        # See https://jira.mesosphere.com/browse/DCOS_OSS-2501
+        # See https://jira.d2iq.com/browse/DCOS_OSS-2501
         # for removing "check_time: 'false'".
         return {
             'check_time': 'false',

--- a/src/dcos_e2e_cli/_vendor/dcos_installer_tools/artifact_utils.py
+++ b/src/dcos_e2e_cli/_vendor/dcos_installer_tools/artifact_utils.py
@@ -69,7 +69,7 @@ def get_dcos_installer_details(
     if ' ' in str(installer):
         message = (
             'No spaces allowed in path to the installer. '
-            'See https://jira.mesosphere.com/browse/DCOS_OSS-4429.'
+            'See https://jira.d2iq.com/browse/DCOS_OSS-4429.'
         )
         raise ValueError(message)
 

--- a/src/dcos_e2e_cli/_vendor/dcos_launch/platforms/onprem.py
+++ b/src/dcos_e2e_cli/_vendor/dcos_launch/platforms/onprem.py
@@ -256,7 +256,7 @@ def do_postflight(client: ssh_client.AsyncSshClient):
     """Runs a script that will check if DC/OS is operational without needing to authenticate
 
     It waits 20mins+ for the cluster poststart checks to succeed.
-    See https://jira.mesosphere.com/browse/DCOS-41568.
+    See https://jira.d2iq.com/browse/DCOS-41568.
     """
     postflight_script = """
 function run_command_until_success() {

--- a/src/dcos_e2e_cli/dcos_docker/commands/doctor.py
+++ b/src/dcos_e2e_cli/dcos_docker/commands/doctor.py
@@ -360,7 +360,7 @@ def _check_systemd() -> CheckLevels:
     """
     Check that the host supports systemd.
 
-    See https://jira.mesosphere.com/browse/DCOS_OSS-4475 for removing the need
+    See https://jira.d2iq.com/browse/DCOS_OSS-4475 for removing the need
     for this.
     """
     client = docker_client()

--- a/src/dcos_e2e_cli/dcos_vagrant/commands/_common.py
+++ b/src/dcos_e2e_cli/dcos_vagrant/commands/_common.py
@@ -213,7 +213,7 @@ class ClusterVMs(ClusterRepresentation):
         # the library.
         # Instead, we should set different Virtualbox descriptions for
         # different node types.
-        # see https://jira.mesosphere.com/browse/DCOS_OSS-3851.
+        # see https://jira.d2iq.com/browse/DCOS_OSS-3851.
         vm_names = self._vm_names()
         return set(name for name in vm_names if '-master-' in name)
 

--- a/tests/test_cli/test_dcos_docker/test_cli.py
+++ b/tests/test_cli/test_dcos_docker/test_cli.py
@@ -358,11 +358,11 @@ class TestCreate:
         # https://github.com/google/yapf/issues/524.
         # yapf: disable
         expected_message = dedent(
-           """\
-           Usage: minidcos docker create [OPTIONS] INSTALLER
+            """\
+            Usage: minidcos docker create [OPTIONS] INSTALLER
 
-           Error: Invalid value for "--extra-config": "example" is not a valid DC/OS configuration
-            """,# noqa: E501,E261
+            Error: Invalid value for "--extra-config": "example" is not a valid DC/OS configuration
+            """,  # noqa: E501
         )
         # yapf: enable
         assert result.output == expected_message
@@ -394,11 +394,11 @@ class TestCreate:
         # https://github.com/google/yapf/issues/524.
         # yapf: disable
         expected_message = dedent(
-           """\
+            """\
             Usage: minidcos docker create [OPTIONS] INSTALLER
 
             Error: Invalid value for "-c" / "--cluster-id": Invalid cluster id "{cluster_id}", only [a-zA-Z0-9][a-zA-Z0-9_.-] are allowed and the cluster ID cannot be empty.
-            """,# noqa: E501,E261
+            """,  # noqa: E501
         ).format(cluster_id=invalid_id)
         # yapf: enable
         assert result.output == expected_message


### PR DESCRIPTION
Update google-api-python-client to fix conflicting dependency.

Tests failing with
```
pkg_resources.ContextualVersionConflict: (rsa 4.1 (/home/travis/virtualenv/python3.5.6/lib/python3.5/site-packages), Requirement.parse('rsa<4.1,>=3.1.4'), {'google-auth'})
```

Fix some other non-breaking conflicts in the dev dependencies.