### PR TITLE
Add support for CentOS 8 on Docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,8 @@ env:
   - CI_PATTERN=tests/test_dcos_e2e/backends/aws/test_distributions.py::TestRHEL7::test_enterprise
   - CI_PATTERN=tests/test_dcos_e2e/backends/aws/test_aws.py::TestTags
   - CI_PATTERN=tests/test_dcos_e2e/backends/docker/test_distributions.py::TestCentos7
+  - CI_PATTERN=tests/test_dcos_e2e/backends/docker/test_distributions.py::TestCentos8::test_enterprise
+  - CI_PATTERN=tests/test_dcos_e2e/backends/docker/test_distributions.py::TestCentos8::test_oss
   - CI_PATTERN=tests/test_dcos_e2e/backends/docker/test_distributions.py::TestCoreOS::test_enterprise
   - CI_PATTERN=tests/test_dcos_e2e/backends/docker/test_distributions.py::TestCoreOS::test_oss
   - CI_PATTERN=tests/test_dcos_e2e/backends/docker/test_distributions.py::TestUbuntu1604::test_oss

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Next
 ----
 
 * Updated ``google-api-python-client`` to ``v1.7.12``.
+* Added support for CentOS 8 when using Docker.
 
 2020.05.26.0
 ------------

--- a/admin/download_installers.py
+++ b/admin/download_installers.py
@@ -91,6 +91,10 @@ PATTERNS = {
     (),
     'tests/test_dcos_e2e/backends/docker/test_distributions.py::TestCentos7':
     (),
+    'tests/test_dcos_e2e/backends/docker/test_distributions.py::TestCentos8::test_enterprise':  # noqa: E501
+    (EE_MASTER, ),
+    'tests/test_dcos_e2e/backends/docker/test_distributions.py::TestCentos8::test_oss':  # noqa: E501
+    (OSS_MASTER, ),
     'tests/test_dcos_e2e/backends/docker/test_distributions.py::TestCoreOS::test_enterprise':  # noqa: E501
     (EE_MASTER, ),
     'tests/test_dcos_e2e/backends/docker/test_distributions.py::TestCoreOS::test_oss':  # noqa: E501

--- a/src/dcos_e2e/backends/_docker/_docker_build.py
+++ b/src/dcos_e2e/backends/_docker/_docker_build.py
@@ -15,6 +15,7 @@ def _base_dockerfile(linux_distribution: Distribution) -> Path:
     Return the directory including a Dockerfile to use for the base OS image.
     """
     dcos_docker_distros = {
+        Distribution.CENTOS_8: 'centos-8',
         Distribution.CENTOS_7: 'centos-7',
         Distribution.COREOS: 'coreos',
         Distribution.UBUNTU_16_04: 'ubuntu-xenial',

--- a/src/dcos_e2e/backends/_docker/resources/dockerfiles/base/centos-8/Dockerfile
+++ b/src/dcos_e2e/backends/_docker/resources/dockerfiles/base/centos-8/Dockerfile
@@ -1,0 +1,57 @@
+FROM centos:8
+
+RUN yum install -y \
+		bash-completion \
+		bind-utils \
+		ca-certificates \
+		curl \
+		gettext \
+		git \
+		iproute \
+		ipset \
+		iptables \
+		iputils \
+		libcgroup \
+		libselinux-utils \
+		net-tools \
+		openssh-server \
+		sudo \
+		systemd \
+		tar \
+		tree \
+		unzip \
+		which \
+                # This is needed to run DC/OS E2E on hosts with XFS.
+		xfsprogs \
+		xz \
+&& ( \
+cd /lib/systemd/system/sysinit.target.wants/; \
+for i in *; do \
+if [ "$i" != "systemd-tmpfiles-setup.service" ]; then \
+rm -f $i; \
+fi \
+done \
+) \
+&& rm -f /lib/systemd/system/multi-user.target.wants/* \
+&& rm -f /etc/systemd/system/*.wants/* \
+&& rm -f /lib/systemd/system/local-fs.target.wants/* \
+&& rm -f /lib/systemd/system/sockets.target.wants/*udev* \
+&& rm -f /lib/systemd/system/sockets.target.wants/*initctl* \
+&& rm -f /lib/systemd/system/anaconda.target.wants/* \
+&& rm -f /lib/systemd/system/basic.target.wants/* \
+&& rm -f /lib/systemd/system/graphical.target.wants/* \
+&& ln -vf /lib/systemd/system/multi-user.target /lib/systemd/system/default.target
+
+# This works around a systemd bug.
+# See https://jira.d2iq.com/browse/DCOS_OSS-1240
+RUN echo '[Unit]' >> /lib/systemd/system/systemd-journald-init.service
+RUN echo 'Description=Initialize /run/log/journal ACLs' >> /lib/systemd/system/systemd-journald-init.service
+RUN echo 'After=systemd-journald.service' >> /lib/systemd/system/systemd-journald-init.service
+RUN echo '' >> /lib/systemd/system/systemd-journald-init.service
+RUN echo '[Service]' >> /lib/systemd/system/systemd-journald-init.service
+RUN echo 'Type=oneshot' >> /lib/systemd/system/systemd-journald-init.service
+RUN echo 'ExecStart=/usr/bin/systemd-tmpfiles --create --prefix /run/log/journal' >> /lib/systemd/system/systemd-journald-init.service
+RUN echo '' >> /lib/systemd/system/systemd-journald-init.service
+RUN echo '[Install]' >> /lib/systemd/system/systemd-journald-init.service
+RUN echo 'WantedBy=default.target' >> /lib/systemd/system/systemd-journald-init.service
+RUN systemctl enable systemd-journald-init.service || true

--- a/src/dcos_e2e/distributions.py
+++ b/src/dcos_e2e/distributions.py
@@ -16,3 +16,4 @@ class Distribution(Enum):
     COREOS = 2
     UBUNTU_16_04 = 3
     RHEL_7 = 4
+    CENTOS_8 = 5

--- a/src/dcos_e2e_cli/dcos_docker/commands/_linux_distribution.py
+++ b/src/dcos_e2e_cli/dcos_docker/commands/_linux_distribution.py
@@ -10,6 +10,7 @@ from dcos_e2e.distributions import Distribution
 
 _LINUX_DISTRIBUTIONS = {
     'centos-7': Distribution.CENTOS_7,
+    'centos-8': Distribution.CENTOS_8,
     'coreos': Distribution.COREOS,
     'ubuntu-16.04': Distribution.UBUNTU_16_04,
 }

--- a/tests/test_cli/test_dcos_docker/help_outputs/dcos-docker-create.txt
+++ b/tests/test_cli/test_dcos_docker/help_outputs/dcos-docker-create.txt
@@ -32,7 +32,7 @@ Options:
                                   This can be provided by setting the
                                   `MINIDCOS_NODE_DOCKER_VERSION` environment
                                   variable.  [default: 18.06.3-ce]
-  --linux-distribution [centos-7|coreos|ubuntu-16.04]
+  --linux-distribution [centos-7|centos-8|coreos|ubuntu-16.04]
                                   The Linux distribution to use on the nodes.
                                   [default: centos-7]
   --docker-storage-driver [aufs|auto|overlay|overlay2]

--- a/tests/test_cli/test_dcos_docker/help_outputs/dcos-docker-provision.txt
+++ b/tests/test_cli/test_dcos_docker/help_outputs/dcos-docker-provision.txt
@@ -8,7 +8,7 @@ Options:
                                   This can be provided by setting the
                                   `MINIDCOS_NODE_DOCKER_VERSION` environment
                                   variable.  [default: 18.06.3-ce]
-  --linux-distribution [centos-7|coreos|ubuntu-16.04]
+  --linux-distribution [centos-7|centos-8|coreos|ubuntu-16.04]
                                   The Linux distribution to use on the nodes.
                                   [default: centos-7]
   --docker-storage-driver [aufs|auto|overlay|overlay2]

--- a/tests/test_dcos_e2e/backends/docker/test_distributions.py
+++ b/tests/test_dcos_e2e/backends/docker/test_distributions.py
@@ -30,6 +30,7 @@ def _get_node_distribution(node: Node) -> Distribution:
 
     distributions = {
         ('"centos"', '"7"'): Distribution.CENTOS_7,
+        ('"centos"', '"8"'): Distribution.CENTOS_8,
         ('coreos', '1298.7.0'): Distribution.COREOS,
         ('ubuntu', '"16.04"'): Distribution.UBUNTU_16_04,
     }
@@ -61,7 +62,7 @@ def _oss_distribution_test(
         cluster.install_dcos_from_path(
             dcos_installer=oss_installer,
             dcos_config=cluster.base_config,
-            output=Output.CAPTURE,
+            output=Output.LOG_AND_CAPTURE,
             ip_detect_path=cluster_backend.ip_detect_path,
         )
         cluster.wait_for_dcos_oss()
@@ -106,7 +107,7 @@ def _enterprise_distribution_test(
                 **config,
             },
             ip_detect_path=cluster_backend.ip_detect_path,
-            output=Output.CAPTURE,
+            output=Output.LOG_AND_CAPTURE,
         )
         cluster.wait_for_dcos_ee(
             superuser_username=superuser_username,
@@ -153,6 +154,38 @@ class TestCentos7:
             node_distribution = _get_node_distribution(node=master)
 
         assert node_distribution == Distribution.CENTOS_7
+
+
+class TestCentos8:
+    """
+    Tests for the CentOS 8 distribution option.
+    """
+
+    def test_oss(
+        self,
+        oss_installer: Path,
+    ) -> None:
+        """
+        DC/OS OSS can start up on CentOS 8.
+        """
+        _oss_distribution_test(
+            distribution=Distribution.CENTOS_8,
+            oss_installer=oss_installer,
+        )
+
+    def test_enterprise(
+        self,
+        enterprise_installer: Path,
+        license_key_contents: str,
+    ) -> None:
+        """
+        DC/OS Enterprise can start up on CentOS 8.
+        """
+        _enterprise_distribution_test(
+            distribution=Distribution.CENTOS_8,
+            enterprise_installer=enterprise_installer,
+            license_key_contents=license_key_contents,
+        )
 
 
 class TestCoreOS:


### PR DESCRIPTION
Add CentOS 8 as a supported OS for `minidcos docker`