### PR TITLE
Log build errors when creating images for the Docker Mac network

### DIFF
--- a/src/dcos_e2e_cli/dcos_docker/commands/mac_network.py
+++ b/src/dcos_e2e_cli/dcos_docker/commands/mac_network.py
@@ -236,6 +236,13 @@ def setup_mac_network(
             click.echo(message, err=True)
             sys.exit(1)
         raise
+    except docker.errors.BuildError as exc:
+        message = 'Error: There was a problem building a Docker image:\n'
+        click.echo(message, err=True)
+        for line in exc.build_log:
+            if 'stream' in line:
+                click.echo('   ' + line['stream'].strip(), err=True)
+        sys.exit(1)
 
     click.echo(message=configuration_instructions)
 


### PR DESCRIPTION
This change makes the ``minidcos docker setup-mac-network`` command show the build logs when there is a build error.
Without this change a BuildError exception is raised with an error code.
This allows for easier iteration of the ``setup-mac-network`` command.